### PR TITLE
feat: show throttled Action Bar sync progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ WorldEditSync lets players copy a WorldEdit selection on one server and paste it
 
 - Copy once with `//copy` or `//cut`, then paste on another server with `//paste`.
 - Keep the clipboard origin and offset when moving between servers.
+- See clipboard upload and download status in the Action Bar.
 - Use the normal WorldEdit or FAWE workflow without learning extra commands.
 - Control access with the `worldeditsync.sync` permission, which is granted to everyone by default.
 
@@ -186,6 +187,8 @@ Use an endpoint that every backend server can reach. Set `region` when your prov
 
 There are no WorldEditSync commands. Once installed, players continue using normal WorldEdit or FAWE commands.
 
+Action Bar status is enabled by default. Proxy transfers show measured percentage progress. Database and S3 transfers show when synchronization starts and finishes because those services complete each read or write as one operation. Intermediate percentages are combined, require at least a 10% change, and appear at most once per second per player; start and completion are each shown at most once. Set `action-bar.enabled: false` in `plugins/WorldEditSync/config.yml` to hide them.
+
 ## Permissions
 
 `worldeditsync.sync` controls who can synchronize clipboards. It is granted to all players by default. Deny this permission with your permissions plugin when only selected builders should use cross-server clipboards.
@@ -199,6 +202,7 @@ There are no WorldEditSync commands. Once installed, players continue using norm
 | The console reports decryption or token errors | Copy the exact same token to every participating server. Old stored clipboards created with another token cannot be opened. |
 | Database mode keeps retrying | Check the host, port, credentials, firewall, and database permissions from every backend server. |
 | S3 mode keeps retrying | Check the endpoint, bucket, credentials, region, and bucket permissions. |
+| No Action Bar status appears | Confirm `action-bar.enabled` is `true`. Very small transfers may finish before an intermediate percentage needs to be shown. |
 | Velocity or BungeeCord players get different UUIDs | Fix proxy player forwarding before using WorldEditSync. Existing clipboards are stored under the UUID seen by the backend server. |
 | A server cannot download libraries on first startup | Allow the server to reach Maven Central, then restart it. |
 

--- a/src/main/java/dev/twme/worldeditsync/paper/WorldEditSyncPaper.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/WorldEditSyncPaper.java
@@ -18,6 +18,7 @@ import dev.twme.worldeditsync.paper.storage.S3ClipboardStorage;
 import dev.twme.worldeditsync.paper.sync.ProxySyncEngine;
 import dev.twme.worldeditsync.paper.sync.StorageSyncEngine;
 import dev.twme.worldeditsync.paper.sync.SyncEngine;
+import dev.twme.worldeditsync.paper.ui.ActionBarProgress;
 import dev.twme.worldeditsync.paper.update.UpdateChecker;
 
 public class WorldEditSyncPaper extends JavaPlugin {
@@ -27,6 +28,7 @@ public class WorldEditSyncPaper extends JavaPlugin {
     private ClipboardSerializer clipboardSerializer;
     private SyncEngine syncEngine;
     private ClipboardWatcher clipboardWatcher;
+    private ActionBarProgress actionBarProgress;
 
     @Override
     public void onEnable() {
@@ -49,6 +51,7 @@ public class WorldEditSyncPaper extends JavaPlugin {
         // Core components
         clipboardManager = new ClipboardManager();
         clipboardSerializer = new ClipboardSerializer();
+        actionBarProgress = new ActionBarProgress(this, paperConfig.isActionBarEnabled());
         MessageCipher cipher = new MessageCipher(paperConfig.getToken());
 
         if (cipher.isEnabled()) {
@@ -111,12 +114,15 @@ public class WorldEditSyncPaper extends JavaPlugin {
         if (clipboardManager != null) {
             clipboardManager.shutdown();
         }
+        if (actionBarProgress != null) {
+            actionBarProgress.shutdown();
+        }
         getLogger().info("WorldEditSync disabled.");
     }
 
     private void initProxyMode(MessageCipher cipher, PluginMessageCodec pluginMessageCodec) {
         syncEngine = new ProxySyncEngine(this, clipboardManager, clipboardSerializer,
-                cipher, pluginMessageCodec, paperConfig.getTransferConfig());
+                cipher, pluginMessageCodec, paperConfig.getTransferConfig(), actionBarProgress);
         getLogger().info("Initializing Proxy sync mode.");
     }
 
@@ -133,7 +139,7 @@ public class WorldEditSyncPaper extends JavaPlugin {
 
         syncEngine = new StorageSyncEngine(this, clipboardManager, clipboardSerializer,
                 new S3ClipboardStorage(s3), paperConfig.getTransferConfig(),
-                paperConfig.getS3CheckIntervalTicks());
+                paperConfig.getS3CheckIntervalTicks(), actionBarProgress);
         getLogger().info("Initializing S3 sync mode.");
     }
 
@@ -167,7 +173,8 @@ public class WorldEditSyncPaper extends JavaPlugin {
             }
             syncEngine = new StorageSyncEngine(
                     this, clipboardManager, clipboardSerializer, storage,
-                    paperConfig.getTransferConfig(), settings.checkIntervalTicks());
+                    paperConfig.getTransferConfig(), settings.checkIntervalTicks(),
+                    actionBarProgress);
             getLogger().info("Initializing database sync mode (backend: "
                     + settings.type().name().toLowerCase(java.util.Locale.ROOT) + ").");
         } catch (IllegalArgumentException e) {

--- a/src/main/java/dev/twme/worldeditsync/paper/config/PaperConfig.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/config/PaperConfig.java
@@ -8,6 +8,7 @@ public class PaperConfig {
 
     private String syncMode = "proxy";
     private String token = "";
+    private boolean actionBarEnabled = true;
 
     // S3 settings
     private String s3Endpoint = "http://localhost:9000";
@@ -33,6 +34,7 @@ public class PaperConfig {
         syncMode = configuredMode == null ? "" : configuredMode.trim();
         String configuredToken = config.getString("token", "");
         token = configuredToken == null ? "" : configuredToken;
+        actionBarEnabled = config.getBoolean("action-bar.enabled", actionBarEnabled);
 
         s3Endpoint = config.getString("s3.endpoint", s3Endpoint);
         s3AccessKey = config.getString("s3.access-key", s3AccessKey);
@@ -88,6 +90,10 @@ public class PaperConfig {
 
     public String getToken() {
         return token;
+    }
+
+    public boolean isActionBarEnabled() {
+        return actionBarEnabled;
     }
 
     public String getS3Endpoint() {

--- a/src/main/java/dev/twme/worldeditsync/paper/message/PluginMessageHandler.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/message/PluginMessageHandler.java
@@ -26,6 +26,9 @@ import dev.twme.worldeditsync.common.util.HashUtil;
 import dev.twme.worldeditsync.paper.clipboard.ClipboardManager;
 import dev.twme.worldeditsync.paper.clipboard.ClipboardSerializer;
 import dev.twme.worldeditsync.paper.sync.UploadSessionListener;
+import dev.twme.worldeditsync.paper.ui.ActionBarProgress;
+import dev.twme.worldeditsync.paper.ui.ActionBarProgress.Operation;
+import dev.twme.worldeditsync.paper.ui.ActionBarProgress.ProgressHandle;
 import dev.twme.worldeditsync.paper.util.SchedulerUtil;
 
 /**
@@ -40,15 +43,18 @@ public class PluginMessageHandler implements PluginMessageListener {
     private final PluginMessageCodec pluginMessageCodec;
     private final TransferConfig transferConfig;
     private final UploadSessionListener uploadSessionListener;
+    private final ActionBarProgress actionBarProgress;
     private final Logger logger;
     private final InboundMessageLimiter inboundMessageLimiter = new InboundMessageLimiter();
     private final ConcurrentHashMap<UUID, Long> invalidMessageWarnings = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, ProgressHandle> downloadProgress = new ConcurrentHashMap<>();
 
     public PluginMessageHandler(JavaPlugin plugin, ClipboardManager clipboardManager,
                                 ClipboardSerializer clipboardSerializer, MessageCipher cipher,
                                 PluginMessageCodec pluginMessageCodec,
                                 TransferConfig transferConfig,
-                                UploadSessionListener uploadSessionListener) {
+                                UploadSessionListener uploadSessionListener,
+                                ActionBarProgress actionBarProgress) {
         this.plugin = plugin;
         this.clipboardManager = clipboardManager;
         this.clipboardSerializer = clipboardSerializer;
@@ -56,6 +62,7 @@ public class PluginMessageHandler implements PluginMessageListener {
         this.pluginMessageCodec = pluginMessageCodec;
         this.transferConfig = transferConfig;
         this.uploadSessionListener = uploadSessionListener;
+        this.actionBarProgress = actionBarProgress;
         this.logger = plugin.getLogger();
     }
 
@@ -209,6 +216,11 @@ public class PluginMessageHandler implements PluginMessageListener {
         TransferSession session = new TransferSession(sessionId, totalChunks, totalBytes, hash);
         clipboardManager.addDownloadSession(sessionId, session);
         clipboardManager.setActiveSessionId(playerId, sessionId);
+        ProgressHandle progress = actionBarProgress.begin(player, Operation.DOWNLOAD);
+        ProgressHandle previous = downloadProgress.put(sessionId, progress);
+        if (previous != null) {
+            previous.cancel();
+        }
 
         SchedulerUtil.runDelayedAsync(
                 plugin,
@@ -261,8 +273,9 @@ public class PluginMessageHandler implements PluginMessageListener {
             return;
         }
 
+        boolean added;
         try {
-            session.addChunk(chunkIndex, chunkData);
+            added = session.addChunk(chunkIndex, chunkData);
         } catch (IllegalArgumentException e) {
             logger.warning("Rejected invalid download chunk for " + player.getName()
                     + ": " + e.getMessage());
@@ -270,8 +283,17 @@ public class PluginMessageHandler implements PluginMessageListener {
             return;
         }
 
+        if (!added) {
+            return;
+        }
+
         if (session.tryClaimCompletion()) {
             completeDownload(player, session);
+        } else {
+            ProgressHandle progress = downloadProgress.get(sessionId);
+            if (progress != null) {
+                progress.update((double) session.getReceivedBytes() / session.getTotalBytes());
+            }
         }
     }
 
@@ -310,6 +332,7 @@ public class PluginMessageHandler implements PluginMessageListener {
                 || clipboardManager.getState(playerId) != SyncState.DOWNLOADING
                 || !sessionId.equals(clipboardManager.getActiveSessionId(playerId))) {
             clipboardManager.removeDownloadSession(sessionId);
+            cancelDownloadProgress(sessionId);
             if (clipboardManager.isTracked(playerId)
                     && sessionId.equals(clipboardManager.getActiveSessionId(playerId))) {
                 clipboardManager.clearActiveSession(playerId);
@@ -326,6 +349,7 @@ public class PluginMessageHandler implements PluginMessageListener {
             clipboardManager.forceSetState(playerId, SyncState.IDLE);
             player.sendPluginMessage(plugin, Constants.CHANNEL,
                     pluginMessageCodec.encode(ProtocolCodec.encodeDownloadAck(sessionId)));
+            completeDownloadProgress(sessionId);
             logger.info("Clipboard synced for " + player.getName());
         } catch (Exception e) {
             logger.severe("Failed to apply clipboard for " + player.getName() + ": " + e.getMessage());
@@ -363,6 +387,7 @@ public class PluginMessageHandler implements PluginMessageListener {
     private void rejectDownload(Player player, String sessionId, String reason) {
         var playerId = player.getUniqueId();
         clipboardManager.removeDownloadSession(sessionId);
+        failDownloadProgress(sessionId);
         if (!sessionId.equals(clipboardManager.getActiveSessionId(playerId))) {
             return;
         }
@@ -390,6 +415,7 @@ public class PluginMessageHandler implements PluginMessageListener {
 
         var playerId = player.getUniqueId();
         logger.fine("Transfer cancelled for " + player.getName() + ": " + reason);
+        failDownloadProgress(sessionId);
 
         uploadSessionListener.onUploadCancelled(player, sessionId, reason);
 
@@ -434,5 +460,33 @@ public class PluginMessageHandler implements PluginMessageListener {
     public void removePlayer(UUID playerId) {
         invalidMessageWarnings.remove(playerId);
         inboundMessageLimiter.remove(playerId);
+        downloadProgress.forEach((sessionId, progress) -> {
+            if (progress.playerId().equals(playerId)
+                    && downloadProgress.remove(sessionId, progress)) {
+                progress.cancel();
+            }
+        });
+        actionBarProgress.removePlayer(playerId);
+    }
+
+    private void completeDownloadProgress(String sessionId) {
+        ProgressHandle progress = downloadProgress.remove(sessionId);
+        if (progress != null) {
+            progress.complete();
+        }
+    }
+
+    private void failDownloadProgress(String sessionId) {
+        ProgressHandle progress = downloadProgress.remove(sessionId);
+        if (progress != null) {
+            progress.fail();
+        }
+    }
+
+    private void cancelDownloadProgress(String sessionId) {
+        ProgressHandle progress = downloadProgress.remove(sessionId);
+        if (progress != null) {
+            progress.cancel();
+        }
     }
 }

--- a/src/main/java/dev/twme/worldeditsync/paper/sync/ProxySyncEngine.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/sync/ProxySyncEngine.java
@@ -18,6 +18,9 @@ import dev.twme.worldeditsync.common.protocol.ProtocolValidation;
 import dev.twme.worldeditsync.paper.clipboard.ClipboardManager;
 import dev.twme.worldeditsync.paper.clipboard.ClipboardSerializer;
 import dev.twme.worldeditsync.paper.message.PluginMessageHandler;
+import dev.twme.worldeditsync.paper.ui.ActionBarProgress;
+import dev.twme.worldeditsync.paper.ui.ActionBarProgress.Operation;
+import dev.twme.worldeditsync.paper.ui.ActionBarProgress.ProgressHandle;
 import dev.twme.worldeditsync.paper.util.SchedulerUtil;
 
 /**
@@ -31,6 +34,7 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
     private final MessageCipher cipher;
     private final PluginMessageCodec pluginMessageCodec;
     private final TransferConfig transferConfig;
+    private final ActionBarProgress actionBarProgress;
     private final Logger logger;
     private final ConcurrentHashMap<String, PendingUpload> pendingUploads = new ConcurrentHashMap<>();
 
@@ -38,13 +42,15 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
 
     public ProxySyncEngine(JavaPlugin plugin, ClipboardManager clipboardManager,
                            ClipboardSerializer clipboardSerializer, MessageCipher cipher,
-                           PluginMessageCodec pluginMessageCodec, TransferConfig transferConfig) {
+                           PluginMessageCodec pluginMessageCodec, TransferConfig transferConfig,
+                           ActionBarProgress actionBarProgress) {
         this.plugin = plugin;
         this.clipboardManager = clipboardManager;
         this.clipboardSerializer = clipboardSerializer;
         this.cipher = cipher;
         this.pluginMessageCodec = pluginMessageCodec;
         this.transferConfig = transferConfig;
+        this.actionBarProgress = actionBarProgress;
         this.logger = plugin.getLogger();
     }
 
@@ -53,7 +59,7 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
         plugin.getServer().getMessenger().registerOutgoingPluginChannel(plugin, Constants.CHANNEL);
         messageHandler = new PluginMessageHandler(
                 plugin, clipboardManager, clipboardSerializer, cipher, pluginMessageCodec,
-                transferConfig, this);
+                transferConfig, this, actionBarProgress);
         plugin.getServer().getMessenger().registerIncomingPluginChannel(plugin, Constants.CHANNEL, messageHandler);
         logger.info("Proxy sync engine started on channel: " + Constants.CHANNEL);
     }
@@ -62,6 +68,7 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
     public void shutdown() {
         plugin.getServer().getMessenger().unregisterOutgoingPluginChannel(plugin, Constants.CHANNEL);
         plugin.getServer().getMessenger().unregisterIncomingPluginChannel(plugin, Constants.CHANNEL);
+        pendingUploads.values().forEach(upload -> upload.progress.cancel());
         pendingUploads.clear();
         logger.info("Proxy sync engine shut down.");
     }
@@ -109,12 +116,15 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
         String sessionId = UUID.randomUUID().toString();
 
         clipboardManager.setActiveSessionId(playerId, sessionId);
-        pendingUploads.put(sessionId, new PendingUpload(playerId, payload, totalChunks, hash));
+        ProgressHandle progress = actionBarProgress.begin(player, Operation.UPLOAD);
+        pendingUploads.put(sessionId,
+                new PendingUpload(playerId, payload, totalChunks, hash, progress));
 
         if (!player.isOnline()
                 || !clipboardManager.isCurrentPlayerToken(playerId, playerToken)
                 || clipboardManager.getState(playerId) != SyncState.UPLOADING) {
             pendingUploads.remove(sessionId);
+            progress.cancel();
             return;
         }
 
@@ -156,7 +166,7 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
     private void pumpUpload(Player player, String sessionId, PendingUpload upload) {
         if (!player.isOnline()
                 || !sessionId.equals(clipboardManager.getActiveSessionId(upload.playerId))) {
-            failUpload(upload.playerId, sessionId);
+            failUpload(upload, sessionId);
             return;
         }
 
@@ -175,13 +185,15 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
                 upload.touch();
             }
 
+            upload.progress.update((double) upload.nextChunkIndex / upload.totalChunks);
+
             if (upload.nextChunkIndex < upload.totalChunks) {
                 SchedulerUtil.runDelayedOnEntityThread(
                         plugin, player, () -> pumpUpload(player, sessionId, upload), pumpDelayTicks());
             }
         } catch (Exception e) {
             logger.warning("Clipboard upload failed for " + player.getName() + ": " + e.getMessage());
-            failUpload(upload.playerId, sessionId);
+            failUpload(upload, sessionId);
         }
     }
 
@@ -205,7 +217,10 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
             return;
         }
 
-        pendingUploads.remove(sessionId, upload);
+        if (!pendingUploads.remove(sessionId, upload)) {
+            return;
+        }
+        upload.progress.complete();
         if (sessionId.equals(clipboardManager.getActiveSessionId(playerId))) {
             clipboardManager.setLocalHash(playerId, upload.hash);
             clipboardManager.clearActiveSession(playerId);
@@ -221,9 +236,9 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
         if (upload == null || !upload.playerId.equals(player.getUniqueId())) {
             return;
         }
-        pendingUploads.remove(sessionId, upload);
-        failUpload(upload.playerId, sessionId);
-        logger.warning("Clipboard upload cancelled for " + player.getName() + ": " + reason);
+        if (failUpload(upload, sessionId)) {
+            logger.warning("Clipboard upload cancelled for " + player.getName() + ": " + reason);
+        }
     }
 
     @Override
@@ -253,7 +268,7 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
                     transferConfig.getSessionTimeoutMs());
             return;
         }
-        if (!pendingUploads.remove(sessionId, upload)) {
+        if (!failUpload(upload, sessionId)) {
             return;
         }
         SchedulerUtil.runOnEntityThread(plugin, player, () -> {
@@ -262,18 +277,21 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
                         pluginMessageCodec.encode(ProtocolCodec.encodeCancel(sessionId, "upload_timeout")));
             }
         });
-        failUpload(upload.playerId, sessionId);
         logger.warning("Clipboard upload timed out for " + player.getName()
                 + " (session: " + sessionId + ")");
     }
 
-    private void failUpload(UUID playerId, String sessionId) {
-        pendingUploads.remove(sessionId);
-        if (sessionId.equals(clipboardManager.getActiveSessionId(playerId))) {
-            clipboardManager.clearActiveSession(playerId);
-            clipboardManager.forgetClipboard(playerId);
-            clipboardManager.forceSetState(playerId, SyncState.IDLE);
+    private boolean failUpload(PendingUpload upload, String sessionId) {
+        if (!pendingUploads.remove(sessionId, upload)) {
+            return false;
         }
+        upload.progress.fail();
+        if (sessionId.equals(clipboardManager.getActiveSessionId(upload.playerId))) {
+            clipboardManager.clearActiveSession(upload.playerId);
+            clipboardManager.forgetClipboard(upload.playerId);
+            clipboardManager.forceSetState(upload.playerId, SyncState.IDLE);
+        }
+        return true;
     }
 
     @Override
@@ -335,6 +353,7 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
         if (messageHandler != null) {
             messageHandler.removePlayer(playerId);
         }
+        actionBarProgress.removePlayer(playerId);
         clipboardManager.removePlayer(playerId);
     }
 
@@ -347,15 +366,18 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
         private final byte[] payload;
         private final int totalChunks;
         private final String hash;
+        private final ProgressHandle progress;
         private final AtomicBoolean started = new AtomicBoolean();
         private volatile long lastActivityAt = System.currentTimeMillis();
         private int nextChunkIndex;
 
-        private PendingUpload(UUID playerId, byte[] payload, int totalChunks, String hash) {
+        private PendingUpload(UUID playerId, byte[] payload, int totalChunks, String hash,
+                              ProgressHandle progress) {
             this.playerId = playerId;
             this.payload = payload;
             this.totalChunks = totalChunks;
             this.hash = hash;
+            this.progress = progress;
         }
 
         private void touch() {

--- a/src/main/java/dev/twme/worldeditsync/paper/sync/StorageSyncEngine.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/sync/StorageSyncEngine.java
@@ -19,6 +19,9 @@ import dev.twme.worldeditsync.paper.clipboard.ClipboardManager;
 import dev.twme.worldeditsync.paper.clipboard.ClipboardSerializer;
 import dev.twme.worldeditsync.common.storage.ClipboardStorage;
 import dev.twme.worldeditsync.common.storage.StoredClipboard;
+import dev.twme.worldeditsync.paper.ui.ActionBarProgress;
+import dev.twme.worldeditsync.paper.ui.ActionBarProgress.Operation;
+import dev.twme.worldeditsync.paper.ui.ActionBarProgress.ProgressHandle;
 import dev.twme.worldeditsync.paper.util.SchedulerUtil;
 
 /** Synchronizes clipboards through shared storage without network I/O on server threads. */
@@ -33,6 +36,7 @@ public class StorageSyncEngine implements SyncEngine {
     private final ClipboardStorage storage;
     private final TransferConfig transferConfig;
     private final int checkIntervalTicks;
+    private final ActionBarProgress actionBarProgress;
     private final Logger logger;
     private final Object lifecycleLock = new Object();
     private final Semaphore workerSlots = new Semaphore(2);
@@ -47,13 +51,15 @@ public class StorageSyncEngine implements SyncEngine {
 
     public StorageSyncEngine(JavaPlugin plugin, ClipboardManager clipboardManager,
                              ClipboardSerializer clipboardSerializer, ClipboardStorage storage,
-                             TransferConfig transferConfig, int checkIntervalTicks) {
+                             TransferConfig transferConfig, int checkIntervalTicks,
+                             ActionBarProgress actionBarProgress) {
         this.plugin = plugin;
         this.clipboardManager = clipboardManager;
         this.clipboardSerializer = clipboardSerializer;
         this.storage = storage;
         this.transferConfig = transferConfig;
         this.checkIntervalTicks = Math.max(1, checkIntervalTicks);
+        this.actionBarProgress = actionBarProgress;
         this.logger = plugin.getLogger();
         this.storage.setUpdateListener(this::onStorageUpdate);
     }
@@ -178,11 +184,13 @@ public class StorageSyncEngine implements SyncEngine {
         }
 
         String playerName = player.getName();
+        ProgressHandle progress = actionBarProgress.begin(player, Operation.UPLOAD);
         try {
             SchedulerUtil.runAsync(plugin,
                     () -> uploadSerializedClipboard(
-                            playerId, playerToken, playerName, data, hash));
+                            playerId, playerToken, playerName, data, hash, progress));
         } catch (RuntimeException e) {
+            progress.fail();
             finishWorker(playerId, playerToken);
             throw e;
         }
@@ -195,6 +203,7 @@ public class StorageSyncEngine implements SyncEngine {
 
     @Override
     public void onPlayerQuit(Player player) {
+        actionBarProgress.removePlayer(player.getUniqueId());
         clipboardManager.removePlayer(player.getUniqueId());
     }
 
@@ -368,31 +377,38 @@ public class StorageSyncEngine implements SyncEngine {
             return;
         }
 
+        ProgressHandle progress = actionBarProgress.begin(player, Operation.UPLOAD);
         try {
             SchedulerUtil.runAsync(plugin,
                     () -> uploadSerializedClipboard(
-                            playerId, playerToken, playerName, serialized, hash));
+                            playerId, playerToken, playerName, serialized, hash, progress));
         } catch (RuntimeException e) {
+            progress.fail();
             finishWorker(playerId, playerToken);
             throw e;
         }
     }
 
     private void uploadSerializedClipboard(UUID playerId, Object playerToken,
-                                           String playerName, byte[] data, String hash) {
+                                           String playerName, byte[] data, String hash,
+                                           ProgressHandle progress) {
         try {
             if (!running.get() || !ready.get()
                     || !clipboardManager.isCurrentPlayerToken(playerId, playerToken)) {
+                progress.cancel();
                 return;
             }
             storage.upload(playerId.toString(), data, hash, System.currentTimeMillis());
             if (!running.get()
                     || !clipboardManager.isCurrentPlayerToken(playerId, playerToken)) {
+                progress.cancel();
                 return;
             }
             clipboardManager.setLocalHash(playerId, hash);
+            progress.complete();
             logger.fine("Uploaded clipboard to " + storage.description() + " for " + playerName);
         } catch (Exception e) {
+            progress.fail();
             logOperationalFailure(storage.description() + " upload failed for " + playerName, e);
         } finally {
             finishWorker(playerId, playerToken);
@@ -422,35 +438,48 @@ public class StorageSyncEngine implements SyncEngine {
             return false;
         }
 
-        byte[] data = storage.download(playerId.toString(), remote);
-        String actualHash = HashUtil.sha256Hex(data);
-        if (!actualHash.equalsIgnoreCase(remote.hash())) {
-            throw new SecurityException(storage.description() + " clipboard hash mismatch");
-        }
-        Clipboard downloaded = clipboardSerializer.deserialize(data);
-        return scheduleEntityContinuation(player, playerId, playerToken, () -> {
-            if (!running.get()
-                    || !player.isOnline()
-                    || !clipboardManager.isCurrentPlayerToken(playerId, playerToken)
-                    || clipboardManager.getState(playerId) != SyncState.DOWNLOADING
-                    || clipboardSerializer.getPlayerClipboard(player) != expectedClipboard) {
-                if (clipboardManager.isCurrentPlayerToken(playerId, playerToken)
-                        && clipboardManager.getState(playerId) == SyncState.DOWNLOADING) {
+        ProgressHandle progress = actionBarProgress.begin(player, Operation.DOWNLOAD);
+        try {
+            byte[] data = storage.download(playerId.toString(), remote);
+            String actualHash = HashUtil.sha256Hex(data);
+            if (!actualHash.equalsIgnoreCase(remote.hash())) {
+                throw new SecurityException(storage.description() + " clipboard hash mismatch");
+            }
+            Clipboard downloaded = clipboardSerializer.deserialize(data);
+            boolean scheduled = scheduleEntityContinuation(player, playerId, playerToken, () -> {
+                if (!running.get()
+                        || !player.isOnline()
+                        || !clipboardManager.isCurrentPlayerToken(playerId, playerToken)
+                        || clipboardManager.getState(playerId) != SyncState.DOWNLOADING
+                        || clipboardSerializer.getPlayerClipboard(player) != expectedClipboard) {
+                    progress.cancel();
+                    if (clipboardManager.isCurrentPlayerToken(playerId, playerToken)
+                            && clipboardManager.getState(playerId) == SyncState.DOWNLOADING) {
+                        clipboardManager.forceSetState(playerId, SyncState.IDLE);
+                    }
+                    return;
+                }
+                try {
+                    clipboardSerializer.setPlayerClipboard(player, downloaded);
+                    clipboardManager.setLocalHash(playerId, actualHash);
+                    progress.complete();
+                    logger.info("Clipboard synced from " + storage.description() + " for " + playerName);
+                } catch (Exception e) {
+                    progress.fail();
+                    logger.severe("Failed to apply " + storage.description() + " clipboard for "
+                            + playerName + ": " + e.getMessage());
+                } finally {
                     clipboardManager.forceSetState(playerId, SyncState.IDLE);
                 }
-                return;
+            });
+            if (!scheduled) {
+                progress.cancel();
             }
-            try {
-                clipboardSerializer.setPlayerClipboard(player, downloaded);
-                clipboardManager.setLocalHash(playerId, actualHash);
-                logger.info("Clipboard synced from " + storage.description() + " for " + playerName);
-            } catch (Exception e) {
-                logger.severe("Failed to apply " + storage.description() + " clipboard for "
-                        + playerName + ": " + e.getMessage());
-            } finally {
-                clipboardManager.forceSetState(playerId, SyncState.IDLE);
-            }
-        });
+            return scheduled;
+        } catch (Exception e) {
+            progress.fail();
+            throw e;
+        }
     }
 
     private boolean isActiveCheck(Player player, UUID playerId, Object playerToken) {

--- a/src/main/java/dev/twme/worldeditsync/paper/ui/ActionBarProgress.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/ui/ActionBarProgress.java
@@ -1,0 +1,296 @@
+package dev.twme.worldeditsync.paper.ui;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.LongSupplier;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+
+import dev.twme.worldeditsync.paper.util.SchedulerUtil;
+
+/** Displays low-frequency, coalesced clipboard progress in the player's Action Bar. */
+public final class ActionBarProgress {
+
+    static final long UPDATE_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(1L);
+    static final int MINIMUM_PERCENT_STEP = 10;
+    private static final int BAR_WIDTH = 12;
+
+    private final boolean enabled;
+    private final LongSupplier nanoTime;
+    private final BiConsumer<Player, Runnable> entityExecutor;
+    private final BiConsumer<Player, String> messageSender;
+    private final ConcurrentHashMap<UUID, DisplayState> displays = new ConcurrentHashMap<>();
+
+    public ActionBarProgress(JavaPlugin plugin, boolean enabled) {
+        this(
+                enabled,
+                System::nanoTime,
+                (player, task) -> {
+                    if (SchedulerUtil.runOnEntityThread(plugin, player, task) == null) {
+                        throw new IllegalStateException("Player scheduler rejected Action Bar update");
+                    }
+                },
+                ActionBarProgress::sendSpigotActionBar);
+    }
+
+    ActionBarProgress(boolean enabled, LongSupplier nanoTime,
+                      BiConsumer<Player, Runnable> entityExecutor,
+                      BiConsumer<Player, String> messageSender) {
+        this.enabled = enabled;
+        this.nanoTime = nanoTime;
+        this.entityExecutor = entityExecutor;
+        this.messageSender = messageSender;
+    }
+
+    public ProgressHandle begin(Player player, Operation operation) {
+        UUID playerId = player.getUniqueId();
+        Object token = new Object();
+        ProgressHandle handle = new ProgressHandle(player, playerId, token);
+        if (!enabled || !player.isOnline()) {
+            return handle;
+        }
+
+        DisplayState state = new DisplayState(token, operation, nanoTime.getAsLong());
+        displays.put(playerId, state);
+        queue(player, playerId, state, statusMessage(operation), false);
+        return handle;
+    }
+
+    public void removePlayer(UUID playerId) {
+        displays.remove(playerId);
+    }
+
+    public void shutdown() {
+        displays.clear();
+    }
+
+    int activeDisplayCount() {
+        return displays.size();
+    }
+
+    private void update(ProgressHandle handle, double progress) {
+        DisplayState state = currentState(handle);
+        if (state == null || !Double.isFinite(progress)) {
+            return;
+        }
+
+        int percent = Math.max(0, Math.min(99, (int) Math.floor(progress * 100.0)));
+        if (percent < MINIMUM_PERCENT_STEP) {
+            return;
+        }
+
+        boolean schedule = false;
+        long now = nanoTime.getAsLong();
+        synchronized (state) {
+            if (state.terminal || displays.get(handle.playerId) != state
+                    || percent - state.lastPercent < MINIMUM_PERCENT_STEP) {
+                return;
+            }
+
+            if (now < state.nextIntermediateAt || state.scheduled) {
+                return;
+            }
+
+            state.lastPercent = percent;
+            state.pendingMessage = progressMessage(state.operation, percent);
+            state.nextIntermediateAt = now + UPDATE_INTERVAL_NANOS;
+            state.scheduled = true;
+            schedule = true;
+        }
+        if (schedule) {
+            scheduleFlush(handle.player, handle.playerId, state);
+        }
+    }
+
+    private void finish(ProgressHandle handle, boolean success) {
+        DisplayState state = currentState(handle);
+        if (state == null) {
+            return;
+        }
+
+        String message = success
+                ? completionMessage(state.operation)
+                : failureMessage();
+        queue(handle.player, handle.playerId, state, message, true);
+    }
+
+    private void cancel(ProgressHandle handle) {
+        DisplayState state = currentState(handle);
+        if (state != null) {
+            displays.remove(handle.playerId, state);
+        }
+    }
+
+    private DisplayState currentState(ProgressHandle handle) {
+        if (!enabled) {
+            return null;
+        }
+        DisplayState state = displays.get(handle.playerId);
+        return state != null && state.token == handle.token ? state : null;
+    }
+
+    private void queue(Player player, UUID playerId, DisplayState state,
+                       String message, boolean terminal) {
+        boolean schedule = false;
+        synchronized (state) {
+            if (displays.get(playerId) != state || state.terminal) {
+                return;
+            }
+            state.pendingMessage = message;
+            state.terminal = terminal;
+            if (!state.scheduled) {
+                state.scheduled = true;
+                schedule = true;
+            }
+        }
+        if (schedule) {
+            scheduleFlush(player, playerId, state);
+        }
+    }
+
+    private void scheduleFlush(Player player, UUID playerId, DisplayState state) {
+        try {
+            entityExecutor.accept(player, () -> flush(player, playerId, state));
+        } catch (RuntimeException e) {
+            displays.remove(playerId, state);
+        }
+    }
+
+    private void flush(Player player, UUID playerId, DisplayState state) {
+        if (displays.get(playerId) != state) {
+            return;
+        }
+
+        String message;
+        boolean terminal;
+        synchronized (state) {
+            if (displays.get(playerId) != state) {
+                return;
+            }
+            message = state.pendingMessage;
+            terminal = state.terminal;
+            state.pendingMessage = null;
+            state.scheduled = false;
+            state.nextIntermediateAt = Math.max(
+                    state.nextIntermediateAt,
+                    nanoTime.getAsLong() + UPDATE_INTERVAL_NANOS);
+        }
+
+        if (terminal) {
+            displays.remove(playerId, state);
+        }
+        if (message == null || !player.isOnline()) {
+            displays.remove(playerId, state);
+            return;
+        }
+
+        try {
+            messageSender.accept(player, message);
+        } catch (RuntimeException e) {
+            displays.remove(playerId, state);
+        }
+    }
+
+    private static void sendSpigotActionBar(Player player, String message) {
+        player.spigot().sendMessage(
+                ChatMessageType.ACTION_BAR,
+                TextComponent.fromLegacyText(message));
+    }
+
+    private static String statusMessage(Operation operation) {
+        return prefix() + ChatColor.GRAY + operation.status;
+    }
+
+    private static String progressMessage(Operation operation, int percent) {
+        int filled = Math.min(BAR_WIDTH - 1, percent * BAR_WIDTH / 100);
+        String bar = ChatColor.AQUA + "#".repeat(filled)
+                + ChatColor.DARK_GRAY + "-".repeat(BAR_WIDTH - filled);
+        return prefix() + ChatColor.GRAY + operation.verb + " "
+                + ChatColor.DARK_GRAY + "[" + bar + ChatColor.DARK_GRAY + "] "
+                + ChatColor.WHITE + percent + "%";
+    }
+
+    private static String completionMessage(Operation operation) {
+        return prefix() + ChatColor.DARK_GRAY + "[" + ChatColor.GREEN
+                + "#".repeat(BAR_WIDTH) + ChatColor.DARK_GRAY + "] "
+                + ChatColor.WHITE + "100% " + ChatColor.GREEN + operation.completed;
+    }
+
+    private static String failureMessage() {
+        return prefix() + ChatColor.RED + "Clipboard sync failed";
+    }
+
+    private static String prefix() {
+        return ChatColor.AQUA + "WorldEditSync" + ChatColor.DARK_GRAY + " | ";
+    }
+
+    public enum Operation {
+        UPLOAD("Uploading clipboard...", "Uploading", "Clipboard uploaded"),
+        DOWNLOAD("Downloading clipboard...", "Downloading", "Clipboard ready");
+
+        private final String status;
+        private final String verb;
+        private final String completed;
+
+        Operation(String status, String verb, String completed) {
+            this.status = status;
+            this.verb = verb;
+            this.completed = completed;
+        }
+    }
+
+    public final class ProgressHandle {
+        private final Player player;
+        private final UUID playerId;
+        private final Object token;
+
+        private ProgressHandle(Player player, UUID playerId, Object token) {
+            this.player = player;
+            this.playerId = playerId;
+            this.token = token;
+        }
+
+        public UUID playerId() {
+            return playerId;
+        }
+
+        public void update(double progress) {
+            ActionBarProgress.this.update(this, progress);
+        }
+
+        public void complete() {
+            ActionBarProgress.this.finish(this, true);
+        }
+
+        public void fail() {
+            ActionBarProgress.this.finish(this, false);
+        }
+
+        public void cancel() {
+            ActionBarProgress.this.cancel(this);
+        }
+    }
+
+    private static final class DisplayState {
+        private final Object token;
+        private final Operation operation;
+        private long nextIntermediateAt;
+        private int lastPercent;
+        private String pendingMessage;
+        private boolean scheduled;
+        private boolean terminal;
+
+        private DisplayState(Object token, Operation operation, long now) {
+            this.token = token;
+            this.operation = operation;
+            this.nextIntermediateAt = now + UPDATE_INTERVAL_NANOS;
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,6 +14,12 @@ sync-mode: "proxy"
 # S3/database mode may leave this empty, but stored clipboards will be plaintext.
 token: ""
 
+# Show clipboard upload/download status to players in the Action Bar.
+# Intermediate progress updates are coalesced and limited to at most one per
+# second per player. Start and completion are each shown at most once.
+action-bar:
+  enabled: true
+
 # S3 storage settings (only used when sync-mode is "s3")
 s3:
   # S3-compatible endpoint URL (e.g. MinIO server address)

--- a/src/test/java/dev/twme/worldeditsync/paper/config/PaperConfigTest.java
+++ b/src/test/java/dev/twme/worldeditsync/paper/config/PaperConfigTest.java
@@ -47,6 +47,21 @@ public class PaperConfigTest {
         assertEquals(StorageType.POSTGRESQL, config.getDatabaseSettings().type());
     }
 
+    @Test
+    public void canDisableActionBarStatus() {
+        JavaPlugin plugin = mock(JavaPlugin.class);
+        FileConfiguration fileConfig = mock(FileConfiguration.class);
+        when(plugin.getConfig()).thenReturn(fileConfig);
+        when(fileConfig.getString("sync-mode", "proxy")).thenReturn("proxy");
+        when(fileConfig.getString("token", "")).thenReturn("token");
+        when(fileConfig.getBoolean("action-bar.enabled", true)).thenReturn(false);
+
+        PaperConfig config = new PaperConfig();
+        config.load(plugin);
+
+        assertFalse(config.isActionBarEnabled());
+    }
+
     private PaperConfig loadWithMode(String mode) {
         JavaPlugin plugin = mock(JavaPlugin.class);
         FileConfiguration fileConfig = mock(FileConfiguration.class);

--- a/src/test/java/dev/twme/worldeditsync/paper/ui/ActionBarProgressCompatibilityTest.java
+++ b/src/test/java/dev/twme/worldeditsync/paper/ui/ActionBarProgressCompatibilityTest.java
@@ -1,0 +1,30 @@
+package dev.twme.worldeditsync.paper.ui;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+public class ActionBarProgressCompatibilityTest {
+
+    @Test
+    public void usesSpigotActionBarBridgeWithoutPaperAdventureApi() throws IOException {
+        String resourceName = "/" + ActionBarProgress.class.getName().replace('.', '/') + ".class";
+        byte[] bytecode;
+        try (InputStream input = ActionBarProgress.class.getResourceAsStream(resourceName)) {
+            if (input == null) {
+                throw new IOException("Could not read " + resourceName);
+            }
+            bytecode = input.readAllBytes();
+        }
+
+        String constantPool = new String(bytecode, StandardCharsets.ISO_8859_1);
+        assertTrue(constantPool.contains("org/bukkit/entity/Player$Spigot"));
+        assertFalse(constantPool.contains("net/kyori/adventure"));
+        assertFalse(constantPool.contains("sendActionBar"));
+    }
+}

--- a/src/test/java/dev/twme/worldeditsync/paper/ui/ActionBarProgressTest.java
+++ b/src/test/java/dev/twme/worldeditsync/paper/ui/ActionBarProgressTest.java
@@ -1,0 +1,152 @@
+package dev.twme.worldeditsync.paper.ui;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.bukkit.entity.Player;
+import org.junit.Before;
+import org.junit.Test;
+
+import dev.twme.worldeditsync.paper.ui.ActionBarProgress.Operation;
+import dev.twme.worldeditsync.paper.ui.ActionBarProgress.ProgressHandle;
+
+public class ActionBarProgressTest {
+
+    private final AtomicLong now = new AtomicLong();
+    private final Queue<Runnable> scheduled = new ArrayDeque<>();
+    private final List<String> messages = new ArrayList<>();
+    private Player player;
+    private ActionBarProgress progress;
+
+    @Before
+    public void setUp() {
+        player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(UUID.randomUUID());
+        when(player.isOnline()).thenReturn(true);
+        progress = new ActionBarProgress(
+                true,
+                now::get,
+                (ignored, task) -> scheduled.add(task),
+                (ignored, message) -> messages.add(message));
+    }
+
+    @Test
+    public void rateLimitsAndCoalescesIntermediateProgress() {
+        ProgressHandle handle = progress.begin(player, Operation.UPLOAD);
+        runNext();
+
+        assertEquals(1, messages.size());
+        assertTrue(messages.get(0).contains("Uploading clipboard"));
+
+        now.set(TimeUnit.MILLISECONDS.toNanos(999L));
+        handle.update(0.50);
+        assertTrue(scheduled.isEmpty());
+
+        now.set(TimeUnit.SECONDS.toNanos(1L));
+        handle.update(0.09);
+        assertTrue(scheduled.isEmpty());
+
+        handle.update(0.10);
+        handle.update(0.90);
+        assertEquals(1, scheduled.size());
+        runNext();
+
+        assertEquals(2, messages.size());
+        assertTrue(messages.get(1).contains("10%"));
+
+        now.set(TimeUnit.MILLISECONDS.toNanos(1_999L));
+        handle.update(0.95);
+        assertTrue(scheduled.isEmpty());
+
+        now.set(TimeUnit.SECONDS.toNanos(2L));
+        handle.update(0.95);
+        assertEquals(1, scheduled.size());
+
+        handle.complete();
+        assertEquals(1, scheduled.size());
+        runNext();
+
+        assertEquals(3, messages.size());
+        assertTrue(messages.get(2).contains("100%"));
+        assertEquals(0, progress.activeDisplayCount());
+    }
+
+    @Test
+    public void completionReplacesUnsentStartMessage() {
+        ProgressHandle handle = progress.begin(player, Operation.DOWNLOAD);
+        handle.complete();
+
+        assertEquals(1, scheduled.size());
+        runNext();
+
+        assertEquals(1, messages.size());
+        assertTrue(messages.get(0).contains("100%"));
+        assertTrue(messages.get(0).contains("Clipboard ready"));
+    }
+
+    @Test
+    public void delayedStartFlushMovesTheNextProgressWindow() {
+        ProgressHandle handle = progress.begin(player, Operation.UPLOAD);
+        now.set(TimeUnit.SECONDS.toNanos(2L));
+        runNext();
+
+        handle.update(0.50);
+        assertTrue(scheduled.isEmpty());
+
+        now.set(TimeUnit.MILLISECONDS.toNanos(2_999L));
+        handle.update(0.50);
+        assertTrue(scheduled.isEmpty());
+
+        now.set(TimeUnit.SECONDS.toNanos(3L));
+        handle.update(0.50);
+        assertEquals(1, scheduled.size());
+    }
+
+    @Test
+    public void staleHandleCannotReplaceNewOperation() {
+        ProgressHandle stale = progress.begin(player, Operation.UPLOAD);
+        ProgressHandle current = progress.begin(player, Operation.DOWNLOAD);
+
+        stale.complete();
+        runNext();
+        runNext();
+
+        assertEquals(1, messages.size());
+        assertTrue(messages.get(0).contains("Downloading clipboard"));
+
+        current.cancel();
+        assertEquals(0, progress.activeDisplayCount());
+    }
+
+    @Test
+    public void disabledDisplayDoesNotScheduleMessages() {
+        ActionBarProgress disabled = new ActionBarProgress(
+                false,
+                now::get,
+                (ignored, task) -> scheduled.add(task),
+                (ignored, message) -> messages.add(message));
+
+        ProgressHandle handle = disabled.begin(player, Operation.UPLOAD);
+        handle.update(0.5);
+        handle.complete();
+
+        assertTrue(scheduled.isEmpty());
+        assertTrue(messages.isEmpty());
+        assertEquals(0, disabled.activeDisplayCount());
+    }
+
+    private void runNext() {
+        Runnable task = scheduled.remove();
+        task.run();
+    }
+}


### PR DESCRIPTION
## Summary

- show clipboard upload and download status in each player's Action Bar
- report measured percentage progress for proxy transfers
- show start and completion for database/S3 operations, where storage calls are atomic
- allow server owners to disable the display with `action-bar.enabled: false`

## Load safeguards

- keep only one display state per player and discard stale operations
- require at least a 10 percentage-point change before an intermediate update
- send intermediate progress at most once per second per player
- coalesce queued messages; fast transfers can go directly to completion
- send start, completion, and failure at most once
- schedule delivery on the player's entity thread for Folia compatibility
- use the Spigot Action Bar bridge so the plugin remains loadable on Spigot

## Verification

- `mvn -q clean verify`: 50 tests, 48 passed, 2 existing integration tests skipped
- Paper 1.21.11 build 132 + FAWE 2.15.3 + SQLite: copy/upload, reconnect/download, and `//paste -a` restored all 8 test blocks; two Action Bar messages in each direction
- Spigot 1.21.11 build 4598 + WorldEdit 7.4.1 + SQLite: copy/upload and reconnect/download/paste passed
- Folia 1.21.11 build 14 + WorldEdit 7.4.1 + SQLite: copy/upload and reconnect/download/paste passed without region-thread violations
- official BungeeCord build 2083 + Spigot backend + WorldEdit: 598 KiB encrypted proxy transfer under a deliberately small 1 KiB chunk configuration produced only start, three intermediate updates, and completion in each direction; intermediate updates were approximately one second apart
- bytecode compatibility test verifies the Action Bar implementation does not reference Paper Adventure APIs
