### PR TITLE
Harden sync protocol and bound transfer resources

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,20 +8,28 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - velocity-api: '3.4.0'
+            java: '21'
+          - velocity-api: '4.0.0'
+            java: '25'
 
     steps:
       - uses: actions/checkout@v6
-      - name: Set up JDK 21
+      - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: mvn -B -Dvelocity-api.version=${{ matrix.velocity-api }} package --file pom.xml
       - name: Upload JAR
+        if: matrix.velocity-api == '3.4.0'
         uses: actions/upload-artifact@v7
         with:
           name: WorldEditSync

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Only choose one setup. Every participating backend server must use the same setu
 
 - Download the latest `WorldEditSync.jar` from the [releases page](https://github.com/TWME-TW/WorldEditSync/releases).
 - Install WorldEdit on every Paper, Folia, or Spigot server. Paper servers may use FAWE instead.
-- Use the same WorldEditSync version on every participating server and proxy.
+- Use the same WorldEditSync version on every participating server and proxy. Velocity 3.x and 4.x are supported; Velocity 4 requires Java 25.
 - Make sure a player has the same UUID on every backend server. Configure BungeeCord IP forwarding or Velocity player forwarding correctly before testing.
 - Use Java 21 or the newer Java version required by your WorldEdit or FAWE download.
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <java.version>21</java.version>
+    <velocity-api.version>3.4.0</velocity-api.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -26,8 +27,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.15.0</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
       <plugin>
@@ -85,13 +85,13 @@
     <dependency>
       <groupId>io.papermc.paper</groupId>
       <artifactId>paper-api</artifactId>
-      <version>1.21.10-R0.1-SNAPSHOT</version>
+      <version>1.21.11-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.velocitypowered</groupId>
       <artifactId>velocity-api</artifactId>
-      <version>3.4.0</version>
+      <version>${velocity-api.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/dev/twme/worldeditsync/bungeecord/WorldEditSyncBungee.java
+++ b/src/main/java/dev/twme/worldeditsync/bungeecord/WorldEditSyncBungee.java
@@ -14,6 +14,7 @@ import net.md_5.bungee.api.event.PluginMessageEvent;
 import net.md_5.bungee.api.event.PlayerDisconnectEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.api.scheduler.ScheduledTask;
 import net.md_5.bungee.event.EventHandler;
 
 public class WorldEditSyncBungee extends Plugin implements Listener {
@@ -21,6 +22,7 @@ public class WorldEditSyncBungee extends Plugin implements Listener {
     private ClipboardStore store;
     private MessageHandler messageHandler;
     private BungeeConfig config;
+    private ScheduledTask cleanupTask;
 
     @Override
     public void onEnable() {
@@ -37,7 +39,7 @@ public class WorldEditSyncBungee extends Plugin implements Listener {
             return;
         }
 
-        store = new ClipboardStore();
+        store = new ClipboardStore(config.getMemoryLimitBytes());
 
         MessageCipher cipher = new MessageCipher(config.getToken());
         if (cipher.isEnabled()) {
@@ -46,13 +48,13 @@ public class WorldEditSyncBungee extends Plugin implements Listener {
             getLogger().warning("Encryption disabled! Set 'token' in config.yml for secure transfers.");
         }
 
-        PluginMessageCodec pluginMessageCodec = new PluginMessageCodec(config.getToken());
+        PluginMessageCodec pluginMessageCodec = PluginMessageCodec.forProxy(config.getToken());
         messageHandler = new MessageHandler(this, store, config.getChunkSize(),
                 config.getMaxClipboardSize(), config.getChunkSendDelayMs(),
                 config.getSessionTimeoutMs(), pluginMessageCodec);
 
         // Schedule cleanup tasks
-        getProxy().getScheduler().schedule(this, () -> {
+        cleanupTask = getProxy().getScheduler().schedule(this, () -> {
             store.cleanupExpiredSessions(config.getSessionTimeoutMs());
             store.cleanupExpiredClipboards(config.getClipboardTtlMinutes());
         }, 2, 2, TimeUnit.MINUTES);
@@ -63,6 +65,13 @@ public class WorldEditSyncBungee extends Plugin implements Listener {
     @Override
     public void onDisable() {
         getProxy().unregisterChannel(Constants.CHANNEL);
+        if (cleanupTask != null) {
+            cleanupTask.cancel();
+            cleanupTask = null;
+        }
+        if (messageHandler != null) {
+            messageHandler.shutdown();
+        }
         if (store != null) {
             store.shutdown();
         }

--- a/src/main/java/dev/twme/worldeditsync/bungeecord/config/BungeeConfig.java
+++ b/src/main/java/dev/twme/worldeditsync/bungeecord/config/BungeeConfig.java
@@ -10,6 +10,7 @@ import net.md_5.bungee.config.Configuration;
 import net.md_5.bungee.config.ConfigurationProvider;
 import net.md_5.bungee.config.YamlConfiguration;
 import dev.twme.worldeditsync.common.Constants;
+import dev.twme.worldeditsync.common.crypto.MessageCipher;
 
 public class BungeeConfig {
 
@@ -19,11 +20,18 @@ public class BungeeConfig {
     private int chunkSize = 30_000;
     private long chunkSendDelayMs = 5;
     private int maxClipboardSize = 52_428_800;
+    private long memoryLimitBytes = Constants.DEFAULT_TRANSFER_MEMORY_LIMIT_BYTES;
 
     public void load(Plugin plugin) {
         File dataFolder = plugin.getDataFolder();
         if (!dataFolder.exists()) {
-            dataFolder.mkdirs();
+            try {
+                Files.createDirectories(dataFolder.toPath());
+            } catch (IOException e) {
+                plugin.getLogger().severe("Failed to create plugin data directory: "
+                        + e.getMessage());
+                return;
+            }
         }
 
         File configFile = new File(dataFolder, "config.yml");
@@ -48,9 +56,17 @@ public class BungeeConfig {
             chunkSize = config.getInt("transfer.chunk-size", chunkSize);
             chunkSendDelayMs = config.getLong("transfer.chunk-send-delay-ms", chunkSendDelayMs);
             maxClipboardSize = config.getInt("transfer.max-clipboard-size", maxClipboardSize);
-            chunkSize = Math.max(1, Math.min(Constants.MAX_CHUNK_SIZE, chunkSize));
+            memoryLimitBytes = config.getLong(
+                    "transfer.memory-limit-bytes", memoryLimitBytes);
+            chunkSize = Math.max(Constants.MIN_CHUNK_SIZE,
+                    Math.min(Constants.MAX_CHUNK_SIZE, chunkSize));
             maxClipboardSize = Math.max(1, Math.min(
                     Constants.ABSOLUTE_MAX_CLIPBOARD_SIZE, maxClipboardSize));
+            memoryLimitBytes = Math.max(
+                    (long) maxClipboardSize + MessageCipher.ENCRYPTION_OVERHEAD_BYTES,
+                    Math.max(Constants.MIN_TRANSFER_MEMORY_LIMIT_BYTES,
+                            Math.min(Constants.MAX_TRANSFER_MEMORY_LIMIT_BYTES,
+                                    memoryLimitBytes)));
             chunkSendDelayMs = Math.max(0L, Math.min(1_000L, chunkSendDelayMs));
             sessionTimeoutMs = Math.max(5_000L, sessionTimeoutMs);
             clipboardTtlMinutes = Math.max(0L, clipboardTtlMinutes);
@@ -81,5 +97,9 @@ public class BungeeConfig {
 
     public int getMaxClipboardSize() {
         return maxClipboardSize;
+    }
+
+    public long getMemoryLimitBytes() {
+        return memoryLimitBytes;
     }
 }

--- a/src/main/java/dev/twme/worldeditsync/bungeecord/handler/MessageHandler.java
+++ b/src/main/java/dev/twme/worldeditsync/bungeecord/handler/MessageHandler.java
@@ -37,6 +37,7 @@ public class MessageHandler {
     private final InboundMessageLimiter inboundMessageLimiter = new InboundMessageLimiter();
     private final ConcurrentHashMap<UUID, Long> invalidMessageWarnings = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<UUID, String> pendingSyncRequests = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, String> activeDownloads = new ConcurrentHashMap<>();
 
     public MessageHandler(Plugin plugin, ClipboardStore store, int chunkSize, int maxClipboardSize,
                           long chunkSendDelayMs, long sessionTimeoutMs,
@@ -59,6 +60,7 @@ public class MessageHandler {
         }
         ParsedMessage msg = pluginMessageCodec.decode(data);
         if (msg == null) {
+            inboundMessageLimiter.recordInvalidMessage(player.getUniqueId());
             warnInvalidMessage(player, "Invalid protocol message from ");
             return;
         }
@@ -99,7 +101,8 @@ public class MessageHandler {
             return;
         }
 
-        TransferSession session = new TransferSession(sessionId, totalChunks, totalBytes, hash);
+        TransferSession session = new TransferSession(
+                sessionId, totalChunks, totalBytes, chunkSize, hash);
         if (!store.addUploadSession(sessionId, player.getUniqueId(), session)) {
             sendToPlayer(player, ProtocolCodec.encodeCancel(sessionId, "duplicate_session"));
             return;
@@ -152,7 +155,7 @@ public class MessageHandler {
 
         try {
             session.addChunk(chunkIndex, chunkData);
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | IllegalStateException e) {
             rejectUpload(player, sessionId, e.getMessage());
             return;
         }
@@ -168,9 +171,7 @@ public class MessageHandler {
         String playerName = player.getName();
         plugin.getProxy().getScheduler().runAsync(plugin, () -> {
             try {
-                byte[] assembled = session.assemble();
-                if (!store.completeUploadSession(
-                        sessionId, playerId, session, assembled, session.getExpectedHash())) {
+                if (!store.completeUploadSession(sessionId, playerId, session)) {
                     logger.fine("Ignoring stale completed upload for " + playerName
                             + " (session: " + sessionId + ")");
                     return;
@@ -282,6 +283,7 @@ public class MessageHandler {
         byte[] data = payload.getData();
         int totalChunks = (int) Math.ceil((double) data.length / chunkSize);
         String sessionId = UUID.randomUUID().toString();
+        activeDownloads.put(player.getUniqueId(), sessionId);
 
         byte[] beginMsg = ProtocolCodec.encodeDownloadBegin(
                 requestId, sessionId, data.length, totalChunks, payload.getHash());
@@ -292,7 +294,9 @@ public class MessageHandler {
     private void scheduleDownloadPump(ProxiedPlayer player, Server destination, byte[] data,
                                       String sessionId, int totalChunks, int nextChunk) {
         plugin.getProxy().getScheduler().schedule(plugin, () -> {
-            if (!player.isConnected() || player.getServer() != destination) {
+            if (!player.isConnected()
+                    || !sessionId.equals(activeDownloads.get(player.getUniqueId()))
+                    || player.getServer() != destination) {
                 return;
             }
 
@@ -331,6 +335,7 @@ public class MessageHandler {
             logger.warning("Malformed download acknowledgement from " + player.getName());
             return;
         }
+        activeDownloads.remove(player.getUniqueId(), sessionId);
         logger.fine("Download acknowledged by " + player.getName() + " session: " + sessionId);
     }
 
@@ -346,6 +351,7 @@ public class MessageHandler {
         }
 
         store.removeUploadSession(sessionId, player.getUniqueId());
+        activeDownloads.remove(player.getUniqueId(), sessionId);
         logger.fine("Transfer cancelled by " + player.getName() + ": " + reason);
     }
 
@@ -363,7 +369,15 @@ public class MessageHandler {
         pendingSyncRequests.remove(playerId);
         inboundMessageLimiter.remove(playerId);
         invalidMessageWarnings.remove(playerId);
+        activeDownloads.remove(playerId);
         store.removeIncompleteUploadSessionForOwner(playerId);
+    }
+
+    public void shutdown() {
+        pendingSyncRequests.clear();
+        activeDownloads.clear();
+        invalidMessageWarnings.clear();
+        inboundMessageLimiter.clear();
     }
 
     private void warnInvalidMessage(ProxiedPlayer player, String prefix) {

--- a/src/main/java/dev/twme/worldeditsync/bungeecord/storage/ClipboardStore.java
+++ b/src/main/java/dev/twme/worldeditsync/bungeecord/storage/ClipboardStore.java
@@ -1,146 +1,15 @@
 package dev.twme.worldeditsync.bungeecord.storage;
 
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
+import dev.twme.worldeditsync.common.storage.ProxyClipboardStore;
 
-import dev.twme.worldeditsync.common.model.ClipboardPayload;
-import dev.twme.worldeditsync.common.protocol.TransferSession;
+/** BungeeCord-facing type for the shared, memory-bounded proxy store. */
+public class ClipboardStore extends ProxyClipboardStore {
 
-/**
- * Proxy-side clipboard storage for BungeeCord.
- * Stores encrypted clipboard data per player with TTL support.
- */
-public class ClipboardStore {
-
-    private final ConcurrentHashMap<UUID, ClipboardPayload> clipboards = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, TransferSession> uploadSessions = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, UUID> sessionOwners = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<UUID, String> ownerSessions = new ConcurrentHashMap<>();
-
-    // ── Clipboard storage ──
-
-    public void storeClipboard(UUID playerId, byte[] data, String hash) {
-        clipboards.put(playerId, new ClipboardPayload(data, hash));
+    public ClipboardStore() {
+        super();
     }
 
-    /** Commit only if this is still the player's current upload session. */
-    public synchronized boolean completeUploadSession(String sessionId, UUID playerId,
-                                                      TransferSession expectedSession,
-                                                      byte[] data, String hash) {
-        if (!sessionId.equals(ownerSessions.get(playerId))
-                || !playerId.equals(sessionOwners.get(sessionId))
-                || uploadSessions.get(sessionId) != expectedSession) {
-            return false;
-        }
-        clipboards.put(playerId, new ClipboardPayload(data, hash));
-        removeUploadSession(sessionId);
-        return true;
-    }
-
-    public ClipboardPayload getClipboard(UUID playerId) {
-        return clipboards.get(playerId);
-    }
-
-    public boolean hasClipboard(UUID playerId) {
-        return clipboards.containsKey(playerId);
-    }
-
-    // ── Upload session management ──
-
-    public synchronized boolean addUploadSession(String sessionId, UUID playerId, TransferSession session) {
-        if (uploadSessions.containsKey(sessionId)) {
-            return false;
-        }
-        String previousSession = ownerSessions.put(playerId, sessionId);
-        if (previousSession != null) {
-            uploadSessions.remove(previousSession);
-            sessionOwners.remove(previousSession);
-        }
-        uploadSessions.put(sessionId, session);
-        sessionOwners.put(sessionId, playerId);
-        return true;
-    }
-
-    public TransferSession getUploadSession(String sessionId) {
-        return uploadSessions.get(sessionId);
-    }
-
-    public UUID getSessionOwner(String sessionId) {
-        return sessionOwners.get(sessionId);
-    }
-
-    public synchronized void removeUploadSession(String sessionId) {
-        uploadSessions.remove(sessionId);
-        UUID owner = sessionOwners.remove(sessionId);
-        if (owner != null) {
-            ownerSessions.remove(owner, sessionId);
-        }
-    }
-
-    public synchronized boolean removeUploadSession(String sessionId, UUID expectedOwner) {
-        if (!expectedOwner.equals(sessionOwners.get(sessionId))) {
-            return false;
-        }
-        removeUploadSession(sessionId);
-        return true;
-    }
-
-    public synchronized boolean removeUploadSession(String sessionId, UUID expectedOwner,
-                                                    TransferSession expectedSession) {
-        if (uploadSessions.get(sessionId) != expectedSession) {
-            return false;
-        }
-        return removeUploadSession(sessionId, expectedOwner);
-    }
-
-    public boolean hasActiveUpload(UUID playerId) {
-        return ownerSessions.containsKey(playerId);
-    }
-
-    public synchronized TransferSession getUploadSessionForOwner(UUID playerId) {
-        String sessionId = ownerSessions.get(playerId);
-        return sessionId == null ? null : uploadSessions.get(sessionId);
-    }
-
-    public synchronized void removeUploadSessionForOwner(UUID playerId) {
-        String sessionId = ownerSessions.get(playerId);
-        if (sessionId != null) {
-            removeUploadSession(sessionId);
-        }
-    }
-
-    public synchronized void removeIncompleteUploadSessionForOwner(UUID playerId) {
-        String sessionId = ownerSessions.get(playerId);
-        TransferSession session = sessionId == null ? null : uploadSessions.get(sessionId);
-        if (session != null && !session.isComplete()) {
-            removeUploadSession(sessionId);
-        }
-    }
-
-    // ── Cleanup ──
-
-    public synchronized void cleanupExpiredSessions(long timeoutMs) {
-        uploadSessions.entrySet().removeIf(entry -> {
-            if (!entry.getValue().isComplete() && entry.getValue().isExpired(timeoutMs)) {
-                UUID owner = sessionOwners.remove(entry.getKey());
-                if (owner != null) {
-                    ownerSessions.remove(owner, entry.getKey());
-                }
-                return true;
-            }
-            return false;
-        });
-    }
-
-    public void cleanupExpiredClipboards(long ttlMinutes) {
-        if (ttlMinutes <= 0) return;
-        clipboards.entrySet().removeIf(entry -> entry.getValue().isExpired(ttlMinutes));
-    }
-
-    public synchronized void shutdown() {
-        clipboards.clear();
-        uploadSessions.clear();
-        sessionOwners.clear();
-        ownerSessions.clear();
+    public ClipboardStore(long maxMemoryBytes) {
+        super(maxMemoryBytes);
     }
 }

--- a/src/main/java/dev/twme/worldeditsync/common/Constants.java
+++ b/src/main/java/dev/twme/worldeditsync/common/Constants.java
@@ -7,10 +7,11 @@ public final class Constants {
 
     public static final String CHANNEL = "worldeditsync:main";
 
-    public static final byte PROTOCOL_VERSION = 2;
+    public static final byte PROTOCOL_VERSION = 3;
 
     /** Conservative limit supported by Bukkit's plugin messaging transport. */
     public static final int MAX_PLUGIN_MESSAGE_SIZE = 32_766;
+    public static final int MIN_CHUNK_SIZE = 1_024;
     public static final int MAX_CHUNK_SIZE = 30_000;
     public static final int MAX_CANCEL_REASON_LENGTH = 96;
 
@@ -20,14 +21,26 @@ public final class Constants {
     /** Per-player inbound budget, enforced before authentication/decryption. */
     public static final int MAX_INBOUND_MESSAGES_PER_SECOND = 200;
     public static final int MAX_INBOUND_BYTES_PER_SECOND = 8 * 1024 * 1024;
+    public static final int MAX_INVALID_MESSAGES_PER_SECOND = 1_024;
+    public static final long INVALID_MESSAGE_PLAYER_COOLDOWN_MS = 1_000L;
+    public static final long INVALID_MESSAGE_GLOBAL_COOLDOWN_MS = 250L;
 
     public static final int DEFAULT_CHUNK_SIZE = 30_000;
     public static final int DEFAULT_MAX_CLIPBOARD_SIZE = 50 * 1024 * 1024; // 50 MB
     public static final int ABSOLUTE_MAX_CLIPBOARD_SIZE = 256 * 1024 * 1024;
+    public static final long DEFAULT_MAX_CLIPBOARD_BLOCKS = 16_777_216L;
+    public static final long ABSOLUTE_MAX_CLIPBOARD_BLOCKS = 67_108_864L;
+    public static final long MAX_EXPANDED_SCHEMATIC_SIZE = 512L * 1024 * 1024;
+    public static final int MAX_TRANSFER_CHUNKS =
+            (ABSOLUTE_MAX_CLIPBOARD_SIZE + MIN_CHUNK_SIZE - 1) / MIN_CHUNK_SIZE + 1;
+    public static final long DEFAULT_TRANSFER_MEMORY_LIMIT_BYTES = 256L * 1024 * 1024;
+    public static final long MIN_TRANSFER_MEMORY_LIMIT_BYTES = 16L * 1024 * 1024;
+    public static final long MAX_TRANSFER_MEMORY_LIMIT_BYTES = 8L * 1024 * 1024 * 1024;
     public static final long DEFAULT_SESSION_TIMEOUT_MS = 30_000;
     public static final long DEFAULT_CHUNK_SEND_DELAY_MS = 5;
     public static final int DEFAULT_WATCHER_INTERVAL_TICKS = 60; // 3 seconds
     public static final int DEFAULT_WATCHER_INITIAL_DELAY_TICKS = 40;
+    public static final long UNCHANGED_CLIPBOARD_RECHECK_MS = 60_000L;
     public static final long DEFAULT_CLIPBOARD_TTL_MINUTES = 60;
     public static final int INITIAL_SYNC_MAX_ATTEMPTS = 5;
     public static final long INITIAL_SYNC_RETRY_MS = 1_000;

--- a/src/main/java/dev/twme/worldeditsync/common/config/TransferConfig.java
+++ b/src/main/java/dev/twme/worldeditsync/common/config/TransferConfig.java
@@ -1,23 +1,27 @@
 package dev.twme.worldeditsync.common.config;
 
 import dev.twme.worldeditsync.common.Constants;
+import dev.twme.worldeditsync.common.crypto.MessageCipher;
 
 public class TransferConfig {
 
     private int chunkSize = Constants.DEFAULT_CHUNK_SIZE;
     private int maxClipboardSize = Constants.DEFAULT_MAX_CLIPBOARD_SIZE;
+    private long maxClipboardBlocks = Constants.DEFAULT_MAX_CLIPBOARD_BLOCKS;
     private long sessionTimeoutMs = Constants.DEFAULT_SESSION_TIMEOUT_MS;
     private long chunkSendDelayMs = Constants.DEFAULT_CHUNK_SEND_DELAY_MS;
     private int watcherIntervalTicks = Constants.DEFAULT_WATCHER_INTERVAL_TICKS;
     private int watcherInitialDelayTicks = Constants.DEFAULT_WATCHER_INITIAL_DELAY_TICKS;
     private long clipboardTtlMinutes = Constants.DEFAULT_CLIPBOARD_TTL_MINUTES;
+    private long memoryLimitBytes = Constants.DEFAULT_TRANSFER_MEMORY_LIMIT_BYTES;
 
     public int getChunkSize() {
         return chunkSize;
     }
 
     public void setChunkSize(int chunkSize) {
-        this.chunkSize = Math.max(1, Math.min(Constants.MAX_CHUNK_SIZE, chunkSize));
+        this.chunkSize = Math.max(Constants.MIN_CHUNK_SIZE,
+                Math.min(Constants.MAX_CHUNK_SIZE, chunkSize));
     }
 
     public int getMaxClipboardSize() {
@@ -27,6 +31,17 @@ public class TransferConfig {
     public void setMaxClipboardSize(int maxClipboardSize) {
         this.maxClipboardSize = Math.max(1, Math.min(
                 Constants.ABSOLUTE_MAX_CLIPBOARD_SIZE, maxClipboardSize));
+        memoryLimitBytes = Math.max(memoryLimitBytes,
+                (long) this.maxClipboardSize + MessageCipher.ENCRYPTION_OVERHEAD_BYTES);
+    }
+
+    public long getMaxClipboardBlocks() {
+        return maxClipboardBlocks;
+    }
+
+    public void setMaxClipboardBlocks(long maxClipboardBlocks) {
+        this.maxClipboardBlocks = Math.max(1L, Math.min(
+                Constants.ABSOLUTE_MAX_CLIPBOARD_BLOCKS, maxClipboardBlocks));
     }
 
     public long getSessionTimeoutMs() {
@@ -67,5 +82,16 @@ public class TransferConfig {
 
     public void setClipboardTtlMinutes(long clipboardTtlMinutes) {
         this.clipboardTtlMinutes = Math.max(0L, clipboardTtlMinutes);
+    }
+
+    public long getMemoryLimitBytes() {
+        return memoryLimitBytes;
+    }
+
+    public void setMemoryLimitBytes(long memoryLimitBytes) {
+        this.memoryLimitBytes = Math.max(
+                (long) maxClipboardSize + MessageCipher.ENCRYPTION_OVERHEAD_BYTES,
+                Math.max(Constants.MIN_TRANSFER_MEMORY_LIMIT_BYTES,
+                        Math.min(Constants.MAX_TRANSFER_MEMORY_LIMIT_BYTES, memoryLimitBytes)));
     }
 }

--- a/src/main/java/dev/twme/worldeditsync/common/model/ClipboardPayload.java
+++ b/src/main/java/dev/twme/worldeditsync/common/model/ClipboardPayload.java
@@ -1,7 +1,7 @@
 package dev.twme.worldeditsync.common.model;
 
 /**
- * Immutable representation of a clipboard payload stored on the Proxy or S3.
+ * Proxy-owned clipboard payload. Callers must treat the backing data as read-only.
  */
 public class ClipboardPayload {
 
@@ -37,7 +37,12 @@ public class ClipboardPayload {
         if (ttlMinutes <= 0) {
             return false;
         }
-        long age = System.currentTimeMillis() - timestamp;
-        return age > ttlMinutes * 60_000L;
+        long now = System.currentTimeMillis();
+        if (timestamp > now) {
+            return false;
+        }
+        long ttlMillis = ttlMinutes > Long.MAX_VALUE / 60_000L
+                ? Long.MAX_VALUE : ttlMinutes * 60_000L;
+        return now - timestamp >= ttlMillis;
     }
 }

--- a/src/main/java/dev/twme/worldeditsync/common/protocol/InboundMessageLimiter.java
+++ b/src/main/java/dev/twme/worldeditsync/common/protocol/InboundMessageLimiter.java
@@ -2,46 +2,109 @@ package dev.twme.worldeditsync.common.protocol;
 
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
 
 import dev.twme.worldeditsync.common.Constants;
 
-/** Bounds per-player protocol work before messages are decrypted or parsed. */
+/** Bounds protocol work before messages are decrypted or parsed. */
 public final class InboundMessageLimiter {
 
     private static final long WINDOW_MS = 1_000L;
 
     private final ConcurrentHashMap<UUID, Window> windows = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, Long> blockedPlayers = new ConcurrentHashMap<>();
+    private final Window invalidMessages = new Window();
+    private final LongSupplier clock;
+    private volatile long globallyBlockedUntil;
+
+    public InboundMessageLimiter() {
+        this(System::currentTimeMillis);
+    }
+
+    InboundMessageLimiter(LongSupplier clock) {
+        this.clock = clock;
+    }
 
     public boolean tryAcquire(UUID playerId, int bytes) {
         if (playerId == null || bytes < 0 || bytes > Constants.MAX_PLUGIN_MESSAGE_SIZE) {
             return false;
         }
+        long now = clock.getAsLong();
+        if (now < globallyBlockedUntil) {
+            return false;
+        }
+        Long blockedUntil = blockedPlayers.get(playerId);
+        if (blockedUntil != null) {
+            if (now < blockedUntil) {
+                return false;
+            }
+            blockedPlayers.remove(playerId, blockedUntil);
+        }
         return windows.computeIfAbsent(playerId, ignored -> new Window())
-                .tryAcquire(bytes, System.currentTimeMillis());
+                .tryAcquire(bytes, now,
+                        Constants.MAX_INBOUND_MESSAGES_PER_SECOND,
+                        Constants.MAX_INBOUND_BYTES_PER_SECOND);
+    }
+
+    /**
+     * Applies a cheap per-player circuit breaker after authentication or decoding fails.
+     * A global breaker bounds aggregate work from many attacking connections.
+     */
+    public void recordInvalidMessage(UUID playerId) {
+        if (playerId == null) {
+            return;
+        }
+        long now = clock.getAsLong();
+        blockedPlayers.put(playerId, saturatingAdd(
+                now, Constants.INVALID_MESSAGE_PLAYER_COOLDOWN_MS));
+        if (!invalidMessages.tryAcquire(0, now,
+                Constants.MAX_INVALID_MESSAGES_PER_SECOND, Integer.MAX_VALUE)) {
+            globallyBlockedUntil = saturatingAdd(
+                    now, Constants.INVALID_MESSAGE_GLOBAL_COOLDOWN_MS);
+        }
     }
 
     public void remove(UUID playerId) {
         windows.remove(playerId);
+        blockedPlayers.remove(playerId);
+    }
+
+    public void clear() {
+        windows.clear();
+        blockedPlayers.clear();
+        invalidMessages.reset();
+        globallyBlockedUntil = 0L;
+    }
+
+    private long saturatingAdd(long value, long increment) {
+        return value > Long.MAX_VALUE - increment ? Long.MAX_VALUE : value + increment;
     }
 
     private static final class Window {
-        private long startedAt = System.currentTimeMillis();
+        private long startedAt = Long.MIN_VALUE;
         private int messages;
         private int bytes;
 
-        private synchronized boolean tryAcquire(int messageBytes, long now) {
-            if (now - startedAt >= WINDOW_MS || now < startedAt) {
+        private synchronized boolean tryAcquire(int messageBytes, long now,
+                                                int maxMessages, int maxBytes) {
+            if (startedAt == Long.MIN_VALUE || now < startedAt
+                    || now - startedAt >= WINDOW_MS) {
                 startedAt = now;
                 messages = 0;
                 bytes = 0;
             }
-            if (messages >= Constants.MAX_INBOUND_MESSAGES_PER_SECOND
-                    || bytes > Constants.MAX_INBOUND_BYTES_PER_SECOND - messageBytes) {
+            if (messages >= maxMessages || bytes > maxBytes - messageBytes) {
                 return false;
             }
             messages++;
             bytes += messageBytes;
             return true;
+        }
+
+        private synchronized void reset() {
+            startedAt = Long.MIN_VALUE;
+            messages = 0;
+            bytes = 0;
         }
     }
 }

--- a/src/main/java/dev/twme/worldeditsync/common/protocol/PluginMessageCodec.java
+++ b/src/main/java/dev/twme/worldeditsync/common/protocol/PluginMessageCodec.java
@@ -3,7 +3,6 @@ package dev.twme.worldeditsync.common.protocol;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
-import java.util.Arrays;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
@@ -23,31 +22,38 @@ public final class PluginMessageCodec {
     private static final int IV_LENGTH = 12;
     private static final int TAG_BITS = 128;
     private static final String ALGORITHM = "AES/GCM/NoPadding";
-    private static final byte[] KEY_CONTEXT = "WorldEditSync/plugin-message/v2\0"
+    private static final byte[] KEY_CONTEXT = "WorldEditSync/plugin-message/v3\0"
             .getBytes(StandardCharsets.US_ASCII);
 
-    private final SecretKeySpec key;
+    private final SecretKeySpec outboundKey;
+    private final SecretKeySpec inboundKey;
     private final SecureRandom secureRandom = new SecureRandom();
 
-    public PluginMessageCodec(String token) {
+    private PluginMessageCodec(String token, String outboundDirection, String inboundDirection) {
         if (token == null || token.isBlank()) {
-            key = null;
+            outboundKey = null;
+            inboundKey = null;
             return;
         }
 
         try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            digest.update(KEY_CONTEXT);
-            key = new SecretKeySpec(
-                    digest.digest(token.getBytes(StandardCharsets.UTF_8)),
-                    "AES");
+            outboundKey = deriveKey(token, outboundDirection);
+            inboundKey = deriveKey(token, inboundDirection);
         } catch (Exception e) {
             throw new SecurityException("Failed to derive plugin-message encryption key", e);
         }
     }
 
+    public static PluginMessageCodec forPaper(String token) {
+        return new PluginMessageCodec(token, "paper-to-proxy", "proxy-to-paper");
+    }
+
+    public static PluginMessageCodec forProxy(String token) {
+        return new PluginMessageCodec(token, "proxy-to-paper", "paper-to-proxy");
+    }
+
     public boolean isEnabled() {
-        return key != null;
+        return outboundKey != null;
     }
 
     public byte[] encode(byte[] protocolMessage) {
@@ -70,7 +76,7 @@ public final class PluginMessageCodec {
             byte[] iv = new byte[IV_LENGTH];
             secureRandom.nextBytes(iv);
             Cipher cipher = Cipher.getInstance(ALGORITHM);
-            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(TAG_BITS, iv));
+            cipher.init(Cipher.ENCRYPT_MODE, outboundKey, new GCMParameterSpec(TAG_BITS, iv));
             cipher.updateAAD(MAGIC);
             byte[] ciphertext = cipher.doFinal(protocolMessage);
 
@@ -101,15 +107,24 @@ public final class PluginMessageCodec {
         }
 
         try {
-            byte[] iv = Arrays.copyOfRange(wireMessage, MAGIC.length, MAGIC.length + IV_LENGTH);
-            byte[] ciphertext = Arrays.copyOfRange(
-                    wireMessage, MAGIC.length + IV_LENGTH, wireMessage.length);
             Cipher cipher = Cipher.getInstance(ALGORITHM);
-            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(TAG_BITS, iv));
+            cipher.init(Cipher.DECRYPT_MODE, inboundKey,
+                    new GCMParameterSpec(TAG_BITS, wireMessage, MAGIC.length, IV_LENGTH));
             cipher.updateAAD(MAGIC);
-            return ProtocolCodec.decode(cipher.doFinal(ciphertext));
+            int ciphertextOffset = MAGIC.length + IV_LENGTH;
+            return ProtocolCodec.decode(cipher.doFinal(
+                    wireMessage, ciphertextOffset, wireMessage.length - ciphertextOffset));
         } catch (Exception e) {
             return null;
         }
+    }
+
+    private static SecretKeySpec deriveKey(String token, String direction) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        digest.update(KEY_CONTEXT);
+        digest.update(direction.getBytes(StandardCharsets.US_ASCII));
+        digest.update((byte) 0);
+        return new SecretKeySpec(
+                digest.digest(token.getBytes(StandardCharsets.UTF_8)), "AES");
     }
 }

--- a/src/main/java/dev/twme/worldeditsync/common/protocol/TransferMemoryBudget.java
+++ b/src/main/java/dev/twme/worldeditsync/common/protocol/TransferMemoryBudget.java
@@ -1,0 +1,51 @@
+package dev.twme.worldeditsync.common.protocol;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/** Shared byte reservation for large in-flight backend transfers. */
+public final class TransferMemoryBudget {
+
+    private final long limitBytes;
+    private final AtomicLong reservedBytes = new AtomicLong();
+
+    public TransferMemoryBudget(long limitBytes) {
+        if (limitBytes <= 0L) {
+            throw new IllegalArgumentException("limitBytes must be positive");
+        }
+        this.limitBytes = limitBytes;
+    }
+
+    public boolean tryReserve(long bytes) {
+        if (bytes <= 0L || bytes > limitBytes) {
+            return false;
+        }
+        while (true) {
+            long current = reservedBytes.get();
+            if (current > limitBytes - bytes) {
+                return false;
+            }
+            if (reservedBytes.compareAndSet(current, current + bytes)) {
+                return true;
+            }
+        }
+    }
+
+    public void release(long bytes) {
+        if (bytes <= 0L) {
+            return;
+        }
+        while (true) {
+            long current = reservedBytes.get();
+            if (current < bytes) {
+                throw new IllegalStateException("Released more transfer memory than was reserved");
+            }
+            if (reservedBytes.compareAndSet(current, current - bytes)) {
+                return;
+            }
+        }
+    }
+
+    public long getReservedBytes() {
+        return reservedBytes.get();
+    }
+}

--- a/src/main/java/dev/twme/worldeditsync/common/protocol/TransferSession.java
+++ b/src/main/java/dev/twme/worldeditsync/common/protocol/TransferSession.java
@@ -1,9 +1,8 @@
 package dev.twme.worldeditsync.common.protocol;
 
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
+
+import dev.twme.worldeditsync.common.Constants;
 
 /**
  * Manages the reception of chunked data transfers.
@@ -14,19 +13,27 @@ public class TransferSession {
     private final String sessionId;
     private final int totalChunks;
     private final int totalBytes;
+    private final int chunkSize;
     private final String expectedHash;
     private final long createdAt;
-    private final AtomicLong lastActivityAt;
-    private final ConcurrentHashMap<Integer, byte[]> chunks = new ConcurrentHashMap<>();
-    private final AtomicInteger receivedBytes = new AtomicInteger();
+    private volatile long lastActivityAt;
+    private final boolean[] received;
+    private byte[] data;
+    private int receivedChunks;
+    private int receivedBytes;
+    private boolean released;
     private final AtomicBoolean completionClaimed = new AtomicBoolean();
 
-    public TransferSession(String sessionId, int totalChunks, int totalBytes, String expectedHash) {
+    public TransferSession(String sessionId, int totalChunks, int totalBytes,
+                           int chunkSize, String expectedHash) {
         if (sessionId == null || sessionId.isBlank()) {
             throw new IllegalArgumentException("sessionId must not be blank");
         }
         if (totalChunks <= 0) {
             throw new IllegalArgumentException("totalChunks must be positive");
+        }
+        if (totalChunks > Constants.MAX_TRANSFER_CHUNKS) {
+            throw new IllegalArgumentException("totalChunks exceeds transfer limit");
         }
         if (totalBytes <= 0) {
             throw new IllegalArgumentException("totalBytes must be positive");
@@ -34,20 +41,26 @@ public class TransferSession {
         if (expectedHash == null || expectedHash.isBlank()) {
             throw new IllegalArgumentException("expectedHash must not be blank");
         }
+        if (!isValidLayout(totalBytes, totalChunks, chunkSize)) {
+            throw new IllegalArgumentException("Invalid transfer layout");
+        }
         this.sessionId = sessionId;
         this.totalChunks = totalChunks;
         this.totalBytes = totalBytes;
+        this.chunkSize = chunkSize;
         this.expectedHash = expectedHash;
         this.createdAt = System.currentTimeMillis();
-        this.lastActivityAt = new AtomicLong(createdAt);
+        this.lastActivityAt = createdAt;
+        this.received = new boolean[totalChunks];
     }
 
     public static boolean isValidLayout(int totalBytes, int totalChunks, int chunkSize) {
         if (totalBytes <= 0 || totalChunks <= 0 || chunkSize <= 0) {
             return false;
         }
-        int expectedChunks = (int) Math.ceil((double) totalBytes / chunkSize);
-        return totalChunks == expectedChunks;
+        long expectedChunks = ((long) totalBytes + chunkSize - 1L) / chunkSize;
+        return totalChunks <= Constants.MAX_TRANSFER_CHUNKS
+                && totalChunks == expectedChunks;
     }
 
     public String getSessionId() {
@@ -70,38 +83,45 @@ public class TransferSession {
         return createdAt;
     }
 
-    public boolean addChunk(int index, byte[] data) {
+    public synchronized boolean addChunk(int index, byte[] chunk) {
+        if (released) {
+            throw new IllegalStateException("Transfer session has been released");
+        }
         if (index < 0 || index >= totalChunks) {
             throw new IllegalArgumentException("Chunk index out of range: " + index);
         }
-        if (data == null || data.length == 0) {
+        if (chunk == null || chunk.length == 0) {
             throw new IllegalArgumentException("Chunk data must not be empty");
         }
-
-        if (chunks.putIfAbsent(index, data) != null) {
+        int offset = Math.toIntExact((long) index * chunkSize);
+        int expectedLength = Math.min(chunkSize, totalBytes - offset);
+        if (chunk.length != expectedLength) {
+            throw new IllegalArgumentException("Chunk length does not match transfer layout");
+        }
+        if (received[index]) {
             return false;
         }
-
-        int newTotal = receivedBytes.addAndGet(data.length);
-        if (newTotal > totalBytes) {
-            chunks.remove(index, data);
-            receivedBytes.addAndGet(-data.length);
-            throw new IllegalArgumentException("Received data exceeds declared transfer size");
+        if (data == null) {
+            data = new byte[totalBytes];
         }
-        lastActivityAt.set(System.currentTimeMillis());
+        System.arraycopy(chunk, 0, data, offset, chunk.length);
+        received[index] = true;
+        receivedChunks++;
+        receivedBytes += chunk.length;
+        lastActivityAt = System.currentTimeMillis();
         return true;
     }
 
-    public int getReceivedChunks() {
-        return chunks.size();
+    public synchronized int getReceivedChunks() {
+        return receivedChunks;
     }
 
-    public int getReceivedBytes() {
-        return receivedBytes.get();
+    public synchronized int getReceivedBytes() {
+        return receivedBytes;
     }
 
-    public boolean isComplete() {
-        return chunks.size() == totalChunks && receivedBytes.get() == totalBytes;
+    public synchronized boolean isComplete() {
+        return !released && receivedChunks == totalChunks && receivedBytes == totalBytes;
     }
 
     public boolean tryClaimCompletion() {
@@ -109,35 +129,31 @@ public class TransferSession {
     }
 
     public boolean isExpired(long timeoutMs) {
-        return System.currentTimeMillis() - lastActivityAt.get() >= timeoutMs;
+        long now = System.currentTimeMillis();
+        return now < lastActivityAt || now - lastActivityAt >= timeoutMs;
     }
 
-    public double getProgress() {
+    public synchronized double getProgress() {
         if (totalChunks == 0) return 1.0;
-        return (double) chunks.size() / totalChunks;
+        return (double) receivedChunks / totalChunks;
     }
 
     /**
      * Assemble all chunks into a single byte array.
      * Must only be called when {@link #isComplete()} returns true.
      */
-    public byte[] assemble() {
-        byte[] result = new byte[totalBytes];
-        int offset = 0;
-        for (int i = 0; i < totalChunks; i++) {
-            byte[] chunk = chunks.get(i);
-            if (chunk == null) {
-                throw new IllegalStateException("Missing chunk " + i + " in session " + sessionId);
-            }
-            if (offset + chunk.length > result.length) {
-                throw new IllegalStateException("Chunk data exceeds declared size in session " + sessionId);
-            }
-            System.arraycopy(chunk, 0, result, offset, chunk.length);
-            offset += chunk.length;
+    public synchronized byte[] assemble() {
+        if (!isComplete() || data == null) {
+            throw new IllegalStateException("Transfer session is incomplete: " + sessionId);
         }
-        if (offset != totalBytes) {
-            throw new IllegalStateException("Assembled size does not match declared size in session " + sessionId);
-        }
-        return result;
+        return data;
+    }
+
+    /** Releases a failed or abandoned transfer's backing buffer. */
+    public synchronized void release() {
+        released = true;
+        data = null;
+        receivedChunks = 0;
+        receivedBytes = 0;
     }
 }

--- a/src/main/java/dev/twme/worldeditsync/common/storage/ProxyClipboardStore.java
+++ b/src/main/java/dev/twme/worldeditsync/common/storage/ProxyClipboardStore.java
@@ -1,0 +1,246 @@
+package dev.twme.worldeditsync.common.storage;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import dev.twme.worldeditsync.common.Constants;
+import dev.twme.worldeditsync.common.model.ClipboardPayload;
+import dev.twme.worldeditsync.common.protocol.TransferSession;
+
+/**
+ * Memory-bounded clipboard and upload storage shared by proxy implementations.
+ * Declared upload sizes are reserved before any large receive buffer is allocated.
+ */
+public class ProxyClipboardStore {
+
+    private final Map<UUID, ClipboardPayload> clipboards = new HashMap<>();
+    private final Map<String, TransferSession> uploadSessions = new HashMap<>();
+    private final Map<String, UUID> sessionOwners = new HashMap<>();
+    private final Map<UUID, String> ownerSessions = new HashMap<>();
+    private final long maxMemoryBytes;
+
+    private long storedBytes;
+    private long reservedUploadBytes;
+
+    public ProxyClipboardStore() {
+        this(Constants.DEFAULT_TRANSFER_MEMORY_LIMIT_BYTES);
+    }
+
+    public ProxyClipboardStore(long maxMemoryBytes) {
+        if (maxMemoryBytes <= 0L) {
+            throw new IllegalArgumentException("maxMemoryBytes must be positive");
+        }
+        this.maxMemoryBytes = maxMemoryBytes;
+    }
+
+    public synchronized boolean storeClipboard(UUID playerId, byte[] data, String hash) {
+        if (playerId == null || data == null || data.length == 0 || hash == null) {
+            return false;
+        }
+        ClipboardPayload previous = clipboards.get(playerId);
+        long previousBytes = previous == null ? 0L : previous.getData().length;
+        if (!makeRoom(data.length - previousBytes, playerId)) {
+            return false;
+        }
+        clipboards.put(playerId, new ClipboardPayload(data, hash));
+        storedBytes += data.length - previousBytes;
+        return true;
+    }
+
+    /** Commits only if this is still the player's current, complete upload. */
+    public synchronized boolean completeUploadSession(String sessionId, UUID playerId,
+                                                       TransferSession expectedSession) {
+        if (!sessionId.equals(ownerSessions.get(playerId))
+                || !playerId.equals(sessionOwners.get(sessionId))
+                || uploadSessions.get(sessionId) != expectedSession
+                || !expectedSession.isComplete()) {
+            return false;
+        }
+
+        byte[] data = expectedSession.assemble();
+        ClipboardPayload previous = clipboards.put(playerId,
+                new ClipboardPayload(data, expectedSession.getExpectedHash()));
+        if (previous != null) {
+            storedBytes -= previous.getData().length;
+        }
+        storedBytes += data.length;
+        detachUploadSession(sessionId);
+        return true;
+    }
+
+    public synchronized ClipboardPayload getClipboard(UUID playerId) {
+        return clipboards.get(playerId);
+    }
+
+    public synchronized boolean hasClipboard(UUID playerId) {
+        return clipboards.containsKey(playerId);
+    }
+
+    public synchronized boolean addUploadSession(String sessionId, UUID playerId,
+                                                 TransferSession session) {
+        if (sessionId == null || playerId == null || session == null
+                || uploadSessions.containsKey(sessionId)) {
+            return false;
+        }
+
+        String previousSessionId = ownerSessions.get(playerId);
+        TransferSession previousSession = previousSessionId == null
+                ? null : uploadSessions.get(previousSessionId);
+        long previousReservation = previousSession == null ? 0L : previousSession.getTotalBytes();
+        long additionalReservation = (long) session.getTotalBytes() - previousReservation;
+        if (!makeRoom(additionalReservation, null)) {
+            return false;
+        }
+        if (previousSessionId != null) {
+            removeUploadSession(previousSessionId);
+        }
+
+        uploadSessions.put(sessionId, session);
+        sessionOwners.put(sessionId, playerId);
+        ownerSessions.put(playerId, sessionId);
+        reservedUploadBytes += session.getTotalBytes();
+        return true;
+    }
+
+    public synchronized TransferSession getUploadSession(String sessionId) {
+        return uploadSessions.get(sessionId);
+    }
+
+    public synchronized UUID getSessionOwner(String sessionId) {
+        return sessionOwners.get(sessionId);
+    }
+
+    public synchronized void removeUploadSession(String sessionId) {
+        TransferSession removed = detachUploadSession(sessionId);
+        if (removed != null) {
+            removed.release();
+        }
+    }
+
+    public synchronized boolean removeUploadSession(String sessionId, UUID expectedOwner) {
+        if (expectedOwner == null || !expectedOwner.equals(sessionOwners.get(sessionId))) {
+            return false;
+        }
+        removeUploadSession(sessionId);
+        return true;
+    }
+
+    public synchronized boolean removeUploadSession(String sessionId, UUID expectedOwner,
+                                                     TransferSession expectedSession) {
+        if (uploadSessions.get(sessionId) != expectedSession) {
+            return false;
+        }
+        return removeUploadSession(sessionId, expectedOwner);
+    }
+
+    public synchronized boolean hasActiveUpload(UUID playerId) {
+        return ownerSessions.containsKey(playerId);
+    }
+
+    public synchronized TransferSession getUploadSessionForOwner(UUID playerId) {
+        String sessionId = ownerSessions.get(playerId);
+        return sessionId == null ? null : uploadSessions.get(sessionId);
+    }
+
+    public synchronized void removeUploadSessionForOwner(UUID playerId) {
+        String sessionId = ownerSessions.get(playerId);
+        if (sessionId != null) {
+            removeUploadSession(sessionId);
+        }
+    }
+
+    public synchronized void removeIncompleteUploadSessionForOwner(UUID playerId) {
+        String sessionId = ownerSessions.get(playerId);
+        TransferSession session = sessionId == null ? null : uploadSessions.get(sessionId);
+        if (session != null && !session.isComplete()) {
+            removeUploadSession(sessionId);
+        }
+    }
+
+    public synchronized void cleanupExpiredSessions(long timeoutMs) {
+        for (String sessionId : uploadSessions.entrySet().stream()
+                .filter(entry -> entry.getValue().isExpired(timeoutMs))
+                .map(Map.Entry::getKey)
+                .toList()) {
+            removeUploadSession(sessionId);
+        }
+    }
+
+    public synchronized void cleanupExpiredClipboards(long ttlMinutes) {
+        if (ttlMinutes <= 0L) {
+            return;
+        }
+        for (UUID playerId : clipboards.entrySet().stream()
+                .filter(entry -> entry.getValue().isExpired(ttlMinutes))
+                .map(Map.Entry::getKey)
+                .toList()) {
+            removeClipboard(playerId);
+        }
+    }
+
+    public synchronized long getUsedMemoryBytes() {
+        return storedBytes + reservedUploadBytes;
+    }
+
+    public synchronized long getStoredBytes() {
+        return storedBytes;
+    }
+
+    public synchronized long getReservedUploadBytes() {
+        return reservedUploadBytes;
+    }
+
+    public synchronized void shutdown() {
+        for (TransferSession session : uploadSessions.values()) {
+            session.release();
+        }
+        clipboards.clear();
+        uploadSessions.clear();
+        sessionOwners.clear();
+        ownerSessions.clear();
+        storedBytes = 0L;
+        reservedUploadBytes = 0L;
+    }
+
+    private boolean makeRoom(long additionalBytes, UUID protectedPlayer) {
+        if (additionalBytes <= 0L) {
+            return true;
+        }
+        if (additionalBytes > maxMemoryBytes
+                || getUsedMemoryBytes() > maxMemoryBytes - additionalBytes) {
+            for (UUID playerId : clipboards.entrySet().stream()
+                    .filter(entry -> !entry.getKey().equals(protectedPlayer))
+                    .sorted(Comparator.comparingLong(entry -> entry.getValue().getTimestamp()))
+                    .map(Map.Entry::getKey)
+                    .toList()) {
+                removeClipboard(playerId);
+                if (getUsedMemoryBytes() <= maxMemoryBytes - additionalBytes) {
+                    return true;
+                }
+            }
+        }
+        return getUsedMemoryBytes() <= maxMemoryBytes - additionalBytes;
+    }
+
+    private void removeClipboard(UUID playerId) {
+        ClipboardPayload removed = clipboards.remove(playerId);
+        if (removed != null) {
+            storedBytes -= removed.getData().length;
+        }
+    }
+
+    /** Removes bookkeeping without releasing data that has moved into clipboard storage. */
+    private TransferSession detachUploadSession(String sessionId) {
+        TransferSession removed = uploadSessions.remove(sessionId);
+        UUID owner = sessionOwners.remove(sessionId);
+        if (owner != null) {
+            ownerSessions.remove(owner, sessionId);
+        }
+        if (removed != null) {
+            reservedUploadBytes -= removed.getTotalBytes();
+        }
+        return removed;
+    }
+}

--- a/src/main/java/dev/twme/worldeditsync/paper/WorldEditSyncPaper.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/WorldEditSyncPaper.java
@@ -4,6 +4,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import dev.twme.worldeditsync.common.crypto.MessageCipher;
 import dev.twme.worldeditsync.common.protocol.PluginMessageCodec;
+import dev.twme.worldeditsync.common.protocol.TransferMemoryBudget;
 import dev.twme.worldeditsync.paper.clipboard.ClipboardManager;
 import dev.twme.worldeditsync.paper.clipboard.ClipboardSerializer;
 import dev.twme.worldeditsync.paper.config.PaperConfig;
@@ -50,6 +51,8 @@ public class WorldEditSyncPaper extends JavaPlugin {
 
         // Core components
         clipboardManager = new ClipboardManager();
+        clipboardManager.setTransferMemoryBudget(new TransferMemoryBudget(
+                paperConfig.getTransferConfig().getMemoryLimitBytes()));
         clipboardSerializer = new ClipboardSerializer();
         actionBarProgress = new ActionBarProgress(this, paperConfig.isActionBarEnabled());
         MessageCipher cipher = new MessageCipher(paperConfig.getToken());
@@ -74,7 +77,7 @@ public class WorldEditSyncPaper extends JavaPlugin {
         } else if (paperConfig.isDatabaseMode()) {
             initDatabaseMode(cipher);
         } else {
-            initProxyMode(cipher, new PluginMessageCodec(paperConfig.getToken()));
+            initProxyMode(cipher, PluginMessageCodec.forPaper(paperConfig.getToken()));
         }
 
         if (syncEngine == null) {
@@ -91,7 +94,7 @@ public class WorldEditSyncPaper extends JavaPlugin {
         // Storage-backed modes have their own polling; proxy mode needs this watcher.
         if (paperConfig.isProxyMode()) {
             clipboardWatcher = new ClipboardWatcher(this, clipboardManager, clipboardSerializer,
-                    syncEngine);
+                    syncEngine, paperConfig.getTransferConfig());
             clipboardWatcher.start(
                     paperConfig.getTransferConfig().getWatcherInitialDelayTicks(),
                     paperConfig.getTransferConfig().getWatcherIntervalTicks());

--- a/src/main/java/dev/twme/worldeditsync/paper/clipboard/ClipboardManager.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/clipboard/ClipboardManager.java
@@ -3,9 +3,12 @@ package dev.twme.worldeditsync.paper.clipboard;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
 
 import dev.twme.worldeditsync.common.model.SyncState;
+import dev.twme.worldeditsync.common.Constants;
 import dev.twme.worldeditsync.common.protocol.TransferSession;
+import dev.twme.worldeditsync.common.protocol.TransferMemoryBudget;
 
 /**
  * Manages per-player sync state, local clipboard hash cache, and active transfer sessions.
@@ -16,8 +19,36 @@ public class ClipboardManager {
     private final ConcurrentHashMap<UUID, AtomicReference<SyncState>> playerStates = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<UUID, Object> playerTokens = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<UUID, String> localHashes = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, SerializedClipboard> serializedClipboards = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<UUID, String> activeSessionIds = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, TransferSession> downloadSessions = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, TransferSession> processingDownloadSessions = new ConcurrentHashMap<>();
+    private volatile TransferMemoryBudget transferMemoryBudget;
+    private final LongSupplier clock;
+
+    public ClipboardManager() {
+        this(System::currentTimeMillis);
+    }
+
+    ClipboardManager(LongSupplier clock) {
+        this.clock = clock;
+    }
+
+    public void setTransferMemoryBudget(TransferMemoryBudget transferMemoryBudget) {
+        this.transferMemoryBudget = transferMemoryBudget;
+    }
+
+    public boolean tryReserveTransferMemory(long bytes) {
+        TransferMemoryBudget budget = transferMemoryBudget;
+        return budget == null || budget.tryReserve(bytes);
+    }
+
+    public void releaseTransferMemory(long bytes) {
+        TransferMemoryBudget budget = transferMemoryBudget;
+        if (budget != null) {
+            budget.release(bytes);
+        }
+    }
 
     // ── State management ──
 
@@ -41,6 +72,7 @@ public class ClipboardManager {
     public void initPlayer(UUID playerId, SyncState initialState) {
         playerTokens.put(playerId, new Object());
         playerStates.put(playerId, new AtomicReference<>(initialState));
+        serializedClipboards.remove(playerId);
     }
 
     /**
@@ -104,6 +136,35 @@ public class ClipboardManager {
 
     public void forgetClipboard(UUID playerId) {
         localHashes.remove(playerId);
+        serializedClipboards.remove(playerId);
+    }
+
+    /** Returns true when this clipboard instance was confirmed recently enough to skip a scan. */
+    public boolean isSerializedClipboard(UUID playerId, Object clipboard) {
+        SerializedClipboard serialized = serializedClipboards.get(playerId);
+        String localHash = localHashes.get(playerId);
+        long now = clock.getAsLong();
+        return clipboard != null && serialized != null && serialized.clipboard == clipboard
+                && serialized.hash.equals(localHash)
+                && now >= serialized.timestamp
+                && now - serialized.timestamp < Constants.UNCHANGED_CLIPBOARD_RECHECK_MS;
+    }
+
+    public void markSerializedClipboard(UUID playerId, Object clipboard, String hash) {
+        if (clipboard != null && hash != null) {
+            serializedClipboards.put(playerId,
+                    new SerializedClipboard(clipboard, hash, clock.getAsLong()));
+        }
+    }
+
+    public void clearSerializedClipboard(UUID playerId, Object expectedClipboard) {
+        if (expectedClipboard == null) {
+            serializedClipboards.remove(playerId);
+        } else {
+            serializedClipboards.computeIfPresent(playerId,
+                    (ignored, serialized) -> serialized.clipboard == expectedClipboard
+                            ? null : serialized);
+        }
     }
 
     // ── Session management ──
@@ -120,16 +181,55 @@ public class ClipboardManager {
         activeSessionIds.remove(playerId);
     }
 
-    public void addDownloadSession(String sessionId, TransferSession session) {
-        downloadSessions.put(sessionId, session);
+    public synchronized boolean addDownloadSession(String sessionId, TransferSession session) {
+        TransferMemoryBudget budget = transferMemoryBudget;
+        if (budget != null && !budget.tryReserve(session.getTotalBytes())) {
+            return false;
+        }
+        TransferSession previous = downloadSessions.putIfAbsent(sessionId, session);
+        if (previous != null) {
+            releaseReservation(session);
+            return false;
+        }
+        return true;
     }
 
     public TransferSession getDownloadSession(String sessionId) {
         return downloadSessions.get(sessionId);
     }
 
-    public void removeDownloadSession(String sessionId) {
-        downloadSessions.remove(sessionId);
+    /** Takes ownership out of the session map while async completion is in progress. */
+    public synchronized boolean detachDownloadSession(
+            String sessionId, TransferSession expectedSession) {
+        if (!downloadSessions.remove(sessionId, expectedSession)) {
+            return false;
+        }
+        TransferSession previous = processingDownloadSessions.putIfAbsent(
+                sessionId, expectedSession);
+        if (previous == null) {
+            return true;
+        }
+        releaseReservation(expectedSession);
+        expectedSession.release();
+        return false;
+    }
+
+    public synchronized void releaseDetachedDownloadSession(TransferSession session) {
+        if (processingDownloadSessions.remove(session.getSessionId(), session)) {
+            releaseReservation(session);
+            session.release();
+        }
+    }
+
+    public synchronized void removeDownloadSession(String sessionId) {
+        TransferSession removed = downloadSessions.remove(sessionId);
+        if (removed == null) {
+            removed = processingDownloadSessions.remove(sessionId);
+        }
+        if (removed != null) {
+            releaseReservation(removed);
+            removed.release();
+        }
     }
 
     // ── Cleanup ──
@@ -138,21 +238,51 @@ public class ClipboardManager {
         playerStates.remove(playerId);
         playerTokens.remove(playerId);
         localHashes.remove(playerId);
+        serializedClipboards.remove(playerId);
         String sessionId = activeSessionIds.remove(playerId);
         if (sessionId != null) {
-            downloadSessions.remove(sessionId);
+            removeDownloadSession(sessionId);
         }
     }
 
-    public void cleanupExpiredSessions(long timeoutMs) {
-        downloadSessions.entrySet().removeIf(entry -> entry.getValue().isExpired(timeoutMs));
+    public synchronized void cleanupExpiredSessions(long timeoutMs) {
+        for (var entry : downloadSessions.entrySet()) {
+            TransferSession session = entry.getValue();
+            if (session.isExpired(timeoutMs)
+                    && downloadSessions.remove(entry.getKey(), session)) {
+                releaseReservation(session);
+                session.release();
+            }
+        }
     }
 
-    public void shutdown() {
+    public synchronized void shutdown() {
         playerStates.clear();
         playerTokens.clear();
         localHashes.clear();
+        serializedClipboards.clear();
         activeSessionIds.clear();
-        downloadSessions.clear();
+        downloadSessions.forEach((sessionId, session) -> {
+            if (downloadSessions.remove(sessionId, session)) {
+                releaseReservation(session);
+                session.release();
+            }
+        });
+        processingDownloadSessions.forEach((sessionId, session) -> {
+            if (processingDownloadSessions.remove(sessionId, session)) {
+                releaseReservation(session);
+                session.release();
+            }
+        });
+    }
+
+    private record SerializedClipboard(Object clipboard, String hash, long timestamp) {
+    }
+
+    private void releaseReservation(TransferSession session) {
+        TransferMemoryBudget budget = transferMemoryBudget;
+        if (budget != null) {
+            releaseTransferMemory(session.getTotalBytes());
+        }
     }
 }

--- a/src/main/java/dev/twme/worldeditsync/paper/clipboard/ClipboardSerializer.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/clipboard/ClipboardSerializer.java
@@ -9,25 +9,40 @@ import com.sk89q.worldedit.extent.clipboard.io.ClipboardWriter;
 import com.sk89q.worldedit.session.ClipboardHolder;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.enginehub.linbus.stream.LinBinaryIO;
-import org.enginehub.linbus.tree.LinCompoundTag;
-import org.enginehub.linbus.tree.LinRootEntry;
-import org.enginehub.linbus.tree.LinTagType;
+
+import dev.twme.worldeditsync.common.Constants;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 public class ClipboardSerializer {
 
-    /**
-     * Get the player's current WorldEdit clipboard, or null if none.
-     */
+    private static final int TAG_END = 0;
+    private static final int TAG_BYTE = 1;
+    private static final int TAG_SHORT = 2;
+    private static final int TAG_INT = 3;
+    private static final int TAG_LONG = 4;
+    private static final int TAG_FLOAT = 5;
+    private static final int TAG_DOUBLE = 6;
+    private static final int TAG_BYTE_ARRAY = 7;
+    private static final int TAG_STRING = 8;
+    private static final int TAG_LIST = 9;
+    private static final int TAG_COMPOUND = 10;
+    private static final int TAG_INT_ARRAY = 11;
+    private static final int TAG_LONG_ARRAY = 12;
+    private static final int MAX_NBT_DEPTH = 64;
+    private static final long MAX_NBT_TAGS = 1_000_000L;
+
+    /** Get the player's current WorldEdit clipboard, or null if none. */
     public Clipboard getPlayerClipboard(Player player) {
         try {
             WorldEditPlugin we = (WorldEditPlugin) Bukkit.getPluginManager().getPlugin("WorldEdit");
@@ -41,74 +56,81 @@ public class ClipboardSerializer {
         }
     }
 
-    /**
-     * Serialize a WorldEdit Clipboard to Sponge V3 schematic bytes.
-     */
+    /** Serialize a WorldEdit Clipboard to canonical Sponge V3 schematic bytes. */
     public byte[] serialize(Clipboard clipboard) throws IOException {
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        try (ClipboardWriter writer = createWriter(bos)) {
+        validateVolume(clipboard, Constants.DEFAULT_MAX_CLIPBOARD_BLOCKS);
+        byte[] data = writeClipboard(clipboard, Constants.DEFAULT_MAX_CLIPBOARD_SIZE);
+        return canonicalize(data);
+    }
+
+    public byte[] serialize(Clipboard clipboard, int maxBytes, long maxBlocks) throws IOException {
+        validateLimits(maxBytes, maxBlocks);
+        validateVolume(clipboard, maxBlocks);
+        return canonicalize(writeClipboard(clipboard, maxBytes), maxBytes, maxBlocks);
+    }
+
+    private byte[] writeClipboard(Clipboard clipboard, int maxBytes) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream(Math.min(maxBytes, 64 * 1024));
+        try (ClipboardWriter writer = createWriter(new BoundedOutputStream(bytes, maxBytes))) {
             writer.write(clipboard);
         }
-        return canonicalize(bos.toByteArray());
+        return bytes.toByteArray();
     }
 
     protected ClipboardWriter createWriter(OutputStream output) throws IOException {
         return BuiltInClipboardFormat.SPONGE_V3_SCHEMATIC.getWriter(output);
     }
 
-    /**
-     * Remove volatile writer metadata so equal clipboard contents produce equal bytes.
-     * WorldEdit writes the current time to Metadata.Date on every serialization.
-     */
+    /** Removes WorldEdit's volatile Metadata.Date without materializing the NBT tree. */
     protected byte[] canonicalize(byte[] data) throws IOException {
-        LinRootEntry root;
-        try (DataInputStream input = new DataInputStream(
-                new GZIPInputStream(new ByteArrayInputStream(data)))) {
-            root = LinRootEntry.readFrom(LinBinaryIO.read(input));
-        }
-
-        LinCompoundTag rootValue = root.value();
-        LinCompoundTag schematic = rootValue.findTag("Schematic", LinTagType.compoundTag());
-        if (schematic == null) {
-            return data;
-        }
-
-        LinCompoundTag metadata = schematic.findTag("Metadata", LinTagType.compoundTag());
-        if (metadata == null || !metadata.value().containsKey("Date")) {
-            return data;
-        }
-
-        LinCompoundTag canonicalMetadata = metadata.toBuilder()
-                .remove("Date")
-                .build();
-        LinCompoundTag canonicalSchematic = schematic.toBuilder()
-                .put("Metadata", canonicalMetadata)
-                .build();
-        LinRootEntry canonicalRoot = new LinRootEntry(
-                root.name(),
-                rootValue.toBuilder().put("Schematic", canonicalSchematic).build());
-
-        ByteArrayOutputStream output = new ByteArrayOutputStream(data.length);
-        try (GZIPOutputStream gzip = new GZIPOutputStream(output);
-             DataOutputStream dataOutput = new DataOutputStream(gzip)) {
-            LinBinaryIO.write(dataOutput, canonicalRoot);
-        }
-        return output.toByteArray();
+        return canonicalize(data, Constants.DEFAULT_MAX_CLIPBOARD_SIZE,
+                Constants.DEFAULT_MAX_CLIPBOARD_BLOCKS);
     }
 
-    /**
-     * Deserialize bytes (Sponge V3 schematic) into a WorldEdit Clipboard.
-     */
+    protected byte[] canonicalize(byte[] data, int maxBytes, long maxBlocks) throws IOException {
+        validateLimits(maxBytes, maxBlocks);
+        if (data == null || data.length == 0 || data.length > maxBytes) {
+            throw new IOException("Schematic exceeds configured compressed size limit");
+        }
+
+        long expandedLimit = expandedLimit(maxBytes, maxBlocks);
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream(Math.min(data.length, 64 * 1024));
+        NbtCopyState state = new NbtCopyState(maxBlocks, expandedLimit);
+        try (DataInputStream input = new DataInputStream(new LimitedInputStream(
+                     new GZIPInputStream(new ByteArrayInputStream(data)), expandedLimit));
+             DataOutputStream output = new DataOutputStream(new GZIPOutputStream(
+                     new BoundedOutputStream(bytes, maxBytes)))) {
+            int rootType = input.readUnsignedByte();
+            if (rootType != TAG_COMPOUND) {
+                throw new IOException("Schematic root must be a compound tag");
+            }
+            output.writeByte(rootType);
+            output.writeUTF(input.readUTF());
+            copyPayload(input, output, rootType, Context.ROOT, null, 0, state);
+            if (input.read() != -1) {
+                throw new IOException("Trailing data after schematic root");
+            }
+        }
+        state.validateDimensions();
+        return bytes.toByteArray();
+    }
+
     public Clipboard deserialize(byte[] data) throws IOException {
-        try (ByteArrayInputStream bis = new ByteArrayInputStream(data);
-             ClipboardReader reader = BuiltInClipboardFormat.SPONGE_V3_SCHEMATIC.getReader(bis)) {
-            return reader.read();
+        return deserialize(data, Constants.DEFAULT_MAX_CLIPBOARD_SIZE,
+                Constants.DEFAULT_MAX_CLIPBOARD_BLOCKS);
+    }
+
+    public Clipboard deserialize(byte[] data, int maxBytes, long maxBlocks) throws IOException {
+        byte[] validated = canonicalize(data, maxBytes, maxBlocks);
+        try (ByteArrayInputStream input = new ByteArrayInputStream(validated);
+             ClipboardReader reader = BuiltInClipboardFormat.SPONGE_V3_SCHEMATIC.getReader(input)) {
+            Clipboard clipboard = reader.read();
+            validateVolume(clipboard, maxBlocks);
+            return clipboard;
         }
     }
 
-    /**
-     * Set the player's WorldEdit clipboard.
-     */
+    /** Set the player's WorldEdit clipboard. */
     public void setPlayerClipboard(Player player, Clipboard clipboard) {
         WorldEditPlugin we = (WorldEditPlugin) Bukkit.getPluginManager().getPlugin("WorldEdit");
         if (we == null) return;
@@ -117,4 +139,265 @@ public class ClipboardSerializer {
         var session = we.getWorldEdit().getSessionManager().get(actor);
         session.setClipboard(new ClipboardHolder(clipboard));
     }
+
+    private static void copyPayload(DataInputStream input, DataOutputStream output, int type,
+                                    Context context, String name, int depth,
+                                    NbtCopyState state) throws IOException {
+        if (depth > MAX_NBT_DEPTH) {
+            throw new IOException("Schematic NBT nesting is too deep");
+        }
+        state.recordTag();
+        switch (type) {
+            case TAG_BYTE -> output.writeByte(input.readByte());
+            case TAG_SHORT -> {
+                short value = input.readShort();
+                output.writeShort(value);
+                state.recordDimension(context, name, Short.toUnsignedInt(value));
+            }
+            case TAG_INT -> {
+                int value = input.readInt();
+                output.writeInt(value);
+                state.recordDimension(context, name, value);
+            }
+            case TAG_LONG -> output.writeLong(input.readLong());
+            case TAG_FLOAT -> output.writeFloat(input.readFloat());
+            case TAG_DOUBLE -> output.writeDouble(input.readDouble());
+            case TAG_BYTE_ARRAY -> copyArray(input, output, 1, state);
+            case TAG_STRING -> output.writeUTF(input.readUTF());
+            case TAG_LIST -> {
+                int elementType = input.readUnsignedByte();
+                int length = input.readInt();
+                validateTagType(elementType, true);
+                if (elementType == TAG_END && length != 0) {
+                    throw new IOException("Non-empty schematic list has no element type");
+                }
+                state.recordCollection(length);
+                output.writeByte(elementType);
+                output.writeInt(length);
+                for (int index = 0; index < length; index++) {
+                    copyPayload(input, output, elementType, Context.OTHER,
+                            null, depth + 1, state);
+                }
+            }
+            case TAG_COMPOUND -> {
+                while (true) {
+                    int childType = input.readUnsignedByte();
+                    if (childType == TAG_END) {
+                        output.writeByte(TAG_END);
+                        break;
+                    }
+                    validateTagType(childType, false);
+                    String childName = input.readUTF();
+                    Context childContext = childContext(context, childType, childName);
+                    boolean removeDate = context == Context.METADATA && "Date".equals(childName);
+                    if (!removeDate) {
+                        output.writeByte(childType);
+                        output.writeUTF(childName);
+                    }
+                    copyPayload(input, removeDate ? state.discarded : output,
+                            childType, childContext, childName, depth + 1, state);
+                }
+            }
+            case TAG_INT_ARRAY -> copyArray(input, output, Integer.BYTES, state);
+            case TAG_LONG_ARRAY -> copyArray(input, output, Long.BYTES, state);
+            default -> throw new IOException("Unsupported schematic NBT tag type: " + type);
+        }
+    }
+
+    private static void copyArray(DataInputStream input, DataOutputStream output,
+                                  int elementBytes, NbtCopyState state) throws IOException {
+        int length = input.readInt();
+        state.recordArray(length, elementBytes);
+        output.writeInt(length);
+        long remaining = (long) length * elementBytes;
+        byte[] buffer = new byte[8 * 1024];
+        while (remaining > 0L) {
+            int amount = (int) Math.min(buffer.length, remaining);
+            input.readFully(buffer, 0, amount);
+            output.write(buffer, 0, amount);
+            remaining -= amount;
+        }
+    }
+
+    private static Context childContext(Context parent, int type, String name) {
+        if (type != TAG_COMPOUND) {
+            return parent;
+        }
+        if (parent == Context.ROOT && "Schematic".equals(name)) {
+            return Context.SCHEMATIC;
+        }
+        if (parent == Context.SCHEMATIC && "Metadata".equals(name)) {
+            return Context.METADATA;
+        }
+        return Context.OTHER;
+    }
+
+    private static void validateTagType(int type, boolean listElement) throws IOException {
+        if (type < TAG_END || type > TAG_LONG_ARRAY || (!listElement && type == TAG_END)) {
+            throw new IOException("Invalid schematic NBT tag type: " + type);
+        }
+    }
+
+    private static void validateLimits(int maxBytes, long maxBlocks) {
+        if (maxBytes <= 0 || maxBlocks <= 0L) {
+            throw new IllegalArgumentException("Clipboard limits must be positive");
+        }
+    }
+
+    private static void validateVolume(Clipboard clipboard, long maxBlocks) throws IOException {
+        if (clipboard == null) {
+            return;
+        }
+        long volume = clipboard.getRegion().getVolume();
+        if (volume <= 0L || volume > maxBlocks) {
+            throw new IOException("Clipboard exceeds configured block limit: " + volume);
+        }
+    }
+
+    private static long expandedLimit(int maxBytes, long maxBlocks) {
+        long byCompressedSize = saturatingMultiply(maxBytes, 4L);
+        long byBlockCount = saturatingAdd(saturatingMultiply(maxBlocks, 6L), 16L * 1024 * 1024);
+        return Math.min(Constants.MAX_EXPANDED_SCHEMATIC_SIZE,
+                Math.max(16L * 1024 * 1024, Math.max(byCompressedSize, byBlockCount)));
+    }
+
+    private static long saturatingMultiply(long value, long multiplier) {
+        return value > Long.MAX_VALUE / multiplier ? Long.MAX_VALUE : value * multiplier;
+    }
+
+    private static long saturatingAdd(long value, long increment) {
+        return value > Long.MAX_VALUE - increment ? Long.MAX_VALUE : value + increment;
+    }
+
+    private enum Context {
+        ROOT,
+        SCHEMATIC,
+        METADATA,
+        OTHER
+    }
+
+    private static final class NbtCopyState {
+        private final long maxBlocks;
+        private final long expandedLimit;
+        private final long maxCollectionElements;
+        private long tags;
+        private int width = -1;
+        private int height = -1;
+        private int length = -1;
+        private final DataOutputStream discarded = new DataOutputStream(OutputStream.nullOutputStream());
+
+        private NbtCopyState(long maxBlocks, long expandedLimit) {
+            this.maxBlocks = maxBlocks;
+            this.expandedLimit = expandedLimit;
+            this.maxCollectionElements = saturatingAdd(maxBlocks, 1_000_000L);
+        }
+
+        private void recordTag() throws IOException {
+            if (++tags > MAX_NBT_TAGS) {
+                throw new IOException("Schematic contains too many NBT tags");
+            }
+        }
+
+        private void recordCollection(int elements) throws IOException {
+            if (elements < 0 || elements > maxCollectionElements) {
+                throw new IOException("Schematic collection exceeds configured element limit");
+            }
+        }
+
+        private void recordArray(int elements, int elementBytes) throws IOException {
+            if (elements < 0 || (long) elements * elementBytes > expandedLimit) {
+                throw new IOException("Schematic array exceeds configured size limit");
+            }
+        }
+
+        private void recordDimension(Context context, String name, int value) throws IOException {
+            if (context != Context.SCHEMATIC || name == null) {
+                return;
+            }
+            switch (name) {
+                case "Width" -> width = uniqueDimension(width, value);
+                case "Height" -> height = uniqueDimension(height, value);
+                case "Length" -> length = uniqueDimension(length, value);
+                default -> {
+                }
+            }
+        }
+
+        private int uniqueDimension(int current, int value) throws IOException {
+            if (current != -1) {
+                throw new IOException("Schematic contains duplicate dimensions");
+            }
+            return value;
+        }
+
+        private void validateDimensions() throws IOException {
+            if (width <= 0 || height <= 0 || length <= 0
+                    || (long) width * height > maxBlocks
+                    || (long) width * height * length > maxBlocks) {
+                throw new IOException("Schematic dimensions exceed configured block limit");
+            }
+        }
+    }
+
+    private static final class BoundedOutputStream extends FilterOutputStream {
+        private final long limit;
+        private long written;
+
+        private BoundedOutputStream(OutputStream output, long limit) {
+            super(output);
+            this.limit = limit;
+        }
+
+        @Override
+        public void write(int value) throws IOException {
+            requireCapacity(1);
+            out.write(value);
+            written++;
+        }
+
+        @Override
+        public void write(byte[] value, int offset, int length) throws IOException {
+            requireCapacity(length);
+            out.write(value, offset, length);
+            written += length;
+        }
+
+        private void requireCapacity(int amount) throws IOException {
+            if (amount < 0 || written > limit - amount) {
+                throw new IOException("Schematic exceeds configured compressed size limit");
+            }
+        }
+    }
+
+    private static final class LimitedInputStream extends FilterInputStream {
+        private final long limit;
+        private long read;
+
+        private LimitedInputStream(InputStream input, long limit) {
+            super(input);
+            this.limit = limit;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int value = in.read();
+            if (value != -1 && ++read > limit) {
+                throw new IOException("Schematic exceeds configured expanded size limit");
+            }
+            return value;
+        }
+
+        @Override
+        public int read(byte[] value, int offset, int length) throws IOException {
+            int amount = in.read(value, offset, length);
+            if (amount > 0 && (read > limit - amount)) {
+                throw new IOException("Schematic exceeds configured expanded size limit");
+            }
+            if (amount > 0) {
+                read += amount;
+            }
+            return amount;
+        }
+    }
+
 }

--- a/src/main/java/dev/twme/worldeditsync/paper/config/PaperConfig.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/config/PaperConfig.java
@@ -61,11 +61,15 @@ public class PaperConfig {
 
         transferConfig.setChunkSize(config.getInt("transfer.chunk-size", transferConfig.getChunkSize()));
         transferConfig.setMaxClipboardSize(config.getInt("transfer.max-clipboard-size", transferConfig.getMaxClipboardSize()));
+        transferConfig.setMaxClipboardBlocks(config.getLong(
+                "transfer.max-clipboard-blocks", transferConfig.getMaxClipboardBlocks()));
         transferConfig.setSessionTimeoutMs(config.getLong("transfer.session-timeout-ms", transferConfig.getSessionTimeoutMs()));
         transferConfig.setChunkSendDelayMs(config.getLong("transfer.chunk-send-delay-ms", transferConfig.getChunkSendDelayMs()));
         transferConfig.setWatcherIntervalTicks(config.getInt("transfer.watcher-interval-ticks", transferConfig.getWatcherIntervalTicks()));
         transferConfig.setWatcherInitialDelayTicks(config.getInt("transfer.watcher-initial-delay-ticks", transferConfig.getWatcherInitialDelayTicks()));
         transferConfig.setClipboardTtlMinutes(config.getLong("transfer.clipboard-ttl-minutes", transferConfig.getClipboardTtlMinutes()));
+        transferConfig.setMemoryLimitBytes(config.getLong(
+                "transfer.memory-limit-bytes", transferConfig.getMemoryLimitBytes()));
     }
 
     public boolean isProxyMode() {

--- a/src/main/java/dev/twme/worldeditsync/paper/listener/ClipboardWatcher.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/listener/ClipboardWatcher.java
@@ -11,6 +11,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 
 import dev.twme.worldeditsync.common.model.SyncState;
+import dev.twme.worldeditsync.common.config.TransferConfig;
 import dev.twme.worldeditsync.common.util.HashUtil;
 import dev.twme.worldeditsync.paper.clipboard.ClipboardManager;
 import dev.twme.worldeditsync.paper.clipboard.ClipboardSerializer;
@@ -28,6 +29,7 @@ public class ClipboardWatcher {
     private final ClipboardManager clipboardManager;
     private final ClipboardSerializer clipboardSerializer;
     private final SyncEngine syncEngine;
+    private final TransferConfig transferConfig;
     private final Logger logger;
     private final Semaphore serializationSlots = new Semaphore(2);
     private final AtomicBoolean scanPending = new AtomicBoolean();
@@ -35,11 +37,13 @@ public class ClipboardWatcher {
     private Object watcherTask;
 
     public ClipboardWatcher(JavaPlugin plugin, ClipboardManager clipboardManager,
-                            ClipboardSerializer clipboardSerializer, SyncEngine syncEngine) {
+                            ClipboardSerializer clipboardSerializer, SyncEngine syncEngine,
+                            TransferConfig transferConfig) {
         this.plugin = plugin;
         this.clipboardManager = clipboardManager;
         this.clipboardSerializer = clipboardSerializer;
         this.syncEngine = syncEngine;
+        this.transferConfig = transferConfig;
         this.logger = plugin.getLogger();
     }
 
@@ -51,27 +55,40 @@ public class ClipboardWatcher {
 
     public void cancel() {
         running.set(false);
-        SchedulerUtil.cancelTask(watcherTask);
+        Object activeTask = watcherTask;
+        watcherTask = null;
+        SchedulerUtil.cancelTask(activeTask);
+        scanPending.set(false);
     }
 
     public void run() {
         if (!running.get() || !scanPending.compareAndSet(false, true)) {
             return;
         }
-        SchedulerUtil.runOnGlobalThread(plugin, () -> {
-            try {
-                for (Player player : plugin.getServer().getOnlinePlayers()) {
-                    SchedulerUtil.runOnEntityThread(plugin, player, () -> detectAndUpload(player));
+        try {
+            if (SchedulerUtil.runOnGlobalThread(plugin, () -> {
+                try {
+                    if (!running.get()) {
+                        return;
+                    }
+                    for (Player player : plugin.getServer().getOnlinePlayers()) {
+                        SchedulerUtil.runOnEntityThread(plugin, player, () -> detectAndUpload(player));
+                    }
+                } finally {
+                    scanPending.set(false);
                 }
-            } finally {
+            }) == null) {
                 scanPending.set(false);
             }
-        });
+        } catch (RuntimeException e) {
+            scanPending.set(false);
+        }
     }
 
     private void detectAndUpload(Player player) {
         UUID playerId = player.getUniqueId();
-        if (!player.isOnline()
+        if (!running.get()
+                || !player.isOnline()
                 || !player.hasPermission("worldeditsync.sync")
                 || !clipboardManager.isTracked(playerId)) {
             return;
@@ -85,6 +102,10 @@ public class ClipboardWatcher {
         try {
             Clipboard clipboard = clipboardSerializer.getPlayerClipboard(player);
             if (clipboard == null) {
+                clipboardManager.forceSetState(playerId, SyncState.IDLE);
+                return;
+            }
+            if (clipboardManager.isSerializedClipboard(playerId, clipboard)) {
                 clipboardManager.forceSetState(playerId, SyncState.IDLE);
                 return;
             }
@@ -117,9 +138,12 @@ public class ClipboardWatcher {
         }
 
         try {
-            SchedulerUtil.runAsync(plugin,
+            if (SchedulerUtil.runAsync(plugin,
                     () -> serializeClipboard(
-                            player, playerId, playerToken, playerName, expectedClipboard));
+                            player, playerId, playerToken, playerName, expectedClipboard)) == null) {
+                serializationSlots.release();
+                resetCheck(playerId, playerToken);
+            }
         } catch (RuntimeException e) {
             serializationSlots.release();
             resetCheck(playerId, playerToken);
@@ -130,12 +154,16 @@ public class ClipboardWatcher {
     private void serializeClipboard(Player player, UUID playerId, Object playerToken,
                                     String playerName, Clipboard clipboard) {
         try {
-            byte[] serialized = clipboardSerializer.serialize(clipboard);
+            byte[] serialized = clipboardSerializer.serialize(
+                    clipboard, transferConfig.getMaxClipboardSize(),
+                    transferConfig.getMaxClipboardBlocks());
             String hash = HashUtil.sha256Hex(serialized);
+            clipboardManager.markSerializedClipboard(playerId, clipboard, hash);
             scheduleEntityContinuation(player, playerId, playerToken,
                     () -> publishIfCurrent(
                             player, playerId, playerToken, clipboard, serialized, hash));
         } catch (Exception e) {
+            clipboardManager.clearSerializedClipboard(playerId, clipboard);
             scheduleEntityContinuation(player, playerId, playerToken,
                     () -> handleSerializationFailure(
                             player, playerId, playerToken, playerName, clipboard, e));
@@ -148,6 +176,7 @@ public class ClipboardWatcher {
                                   Clipboard expectedClipboard, byte[] serialized, String hash) {
         if (!isActiveCheck(player, playerId, playerToken)
                 || clipboardSerializer.getPlayerClipboard(player) != expectedClipboard) {
+            clipboardManager.clearSerializedClipboard(playerId, expectedClipboard);
             resetCheck(playerId, playerToken);
             return;
         }
@@ -158,7 +187,10 @@ public class ClipboardWatcher {
 
         try {
             // Encryption and upload preparation can be proportional to clipboard size.
-            SchedulerUtil.runAsync(plugin, () -> syncEngine.uploadClipboard(player, serialized, hash));
+            if (SchedulerUtil.runAsync(
+                    plugin, () -> syncEngine.uploadClipboard(player, serialized, hash)) == null) {
+                resetCheck(playerId, playerToken);
+            }
         } catch (RuntimeException e) {
             resetCheck(playerId, playerToken);
             throw e;

--- a/src/main/java/dev/twme/worldeditsync/paper/message/PluginMessageHandler.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/message/PluginMessageHandler.java
@@ -78,6 +78,7 @@ public class PluginMessageHandler implements PluginMessageListener {
 
         ParsedMessage msg = pluginMessageCodec.decode(data);
         if (msg == null) {
+            inboundMessageLimiter.recordInvalidMessage(player.getUniqueId());
             warnInvalidMessage(player, "Received invalid or unauthenticated protocol message");
             return;
         }
@@ -213,8 +214,13 @@ public class PluginMessageHandler implements PluginMessageListener {
             return;
         }
 
-        TransferSession session = new TransferSession(sessionId, totalChunks, totalBytes, hash);
-        clipboardManager.addDownloadSession(sessionId, session);
+        TransferSession session = new TransferSession(
+                sessionId, totalChunks, totalBytes, transferConfig.getChunkSize(), hash);
+        if (!clipboardManager.addDownloadSession(sessionId, session)) {
+            warnInvalidMessage(player, "Rejected download because transfer memory is full");
+            sendOnEntityThread(player, ProtocolCodec.encodeCancel(sessionId, "server_busy"));
+            return;
+        }
         clipboardManager.setActiveSessionId(playerId, sessionId);
         ProgressHandle progress = actionBarProgress.begin(player, Operation.DOWNLOAD);
         ProgressHandle previous = downloadProgress.put(sessionId, progress);
@@ -222,10 +228,18 @@ public class PluginMessageHandler implements PluginMessageListener {
             previous.cancel();
         }
 
-        SchedulerUtil.runDelayedAsync(
-                plugin,
-                () -> timeoutDownload(player, sessionId),
-                transferConfig.getSessionTimeoutMs());
+        try {
+            if (SchedulerUtil.runDelayedAsync(
+                    plugin,
+                    () -> timeoutDownload(player, sessionId),
+                    transferConfig.getSessionTimeoutMs()) == null) {
+                rejectDownload(player, sessionId, "scheduler_unavailable");
+                return;
+            }
+        } catch (RuntimeException e) {
+            rejectDownload(player, sessionId, "scheduler_unavailable");
+            return;
+        }
 
         logger.fine("Download begin for " + player.getName() + ": " + totalBytes + " bytes, " + totalChunks + " chunks");
     }
@@ -276,7 +290,7 @@ public class PluginMessageHandler implements PluginMessageListener {
         boolean added;
         try {
             added = session.addChunk(chunkIndex, chunkData);
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | IllegalStateException e) {
             logger.warning("Rejected invalid download chunk for " + player.getName()
                     + ": " + e.getMessage());
             rejectDownload(player, sessionId, "invalid_chunk");
@@ -298,11 +312,17 @@ public class PluginMessageHandler implements PluginMessageListener {
     }
 
     private void completeDownload(Player player, TransferSession session) {
-        var playerId = player.getUniqueId();
         String sessionId = session.getSessionId();
         String playerName = player.getName();
 
-        SchedulerUtil.runAsync(plugin, () -> {
+        if (!clipboardManager.detachDownloadSession(sessionId, session)) {
+            cancelDownloadProgress(sessionId);
+            return;
+        }
+
+        Object completionTask;
+        try {
+            completionTask = SchedulerUtil.runAsync(plugin, () -> {
             try {
                 byte[] assembled = session.assemble();
                 byte[] decrypted = cipher.decrypt(assembled);
@@ -315,14 +335,27 @@ public class PluginMessageHandler implements PluginMessageListener {
                     return;
                 }
 
-                Clipboard clipboard = clipboardSerializer.deserialize(decrypted);
+                Clipboard clipboard = clipboardSerializer.deserialize(
+                        decrypted, transferConfig.getMaxClipboardSize(),
+                        transferConfig.getMaxClipboardBlocks());
                 SchedulerUtil.runOnEntityThread(plugin, player,
                         () -> applyDownloadedClipboard(player, sessionId, clipboard, actualHash));
             } catch (Exception e) {
                 logger.severe("Failed to complete download for " + playerName + ": " + e.getMessage());
                 rejectDownload(player, sessionId, "download_failed");
+            } finally {
+                clipboardManager.releaseDetachedDownloadSession(session);
             }
-        });
+            });
+        } catch (RuntimeException e) {
+            clipboardManager.releaseDetachedDownloadSession(session);
+            rejectDownload(player, sessionId, "scheduler_unavailable");
+            return;
+        }
+        if (completionTask == null) {
+            clipboardManager.releaseDetachedDownloadSession(session);
+            rejectDownload(player, sessionId, "scheduler_unavailable");
+        }
     }
 
     private void applyDownloadedClipboard(Player player, String sessionId,
@@ -344,6 +377,7 @@ public class PluginMessageHandler implements PluginMessageListener {
         try {
             clipboardSerializer.setPlayerClipboard(player, clipboard);
             clipboardManager.setLocalHash(playerId, actualHash);
+            clipboardManager.markSerializedClipboard(playerId, clipboard, actualHash);
             clipboardManager.removeDownloadSession(sessionId);
             clipboardManager.clearActiveSession(playerId);
             clipboardManager.forceSetState(playerId, SyncState.IDLE);
@@ -467,6 +501,16 @@ public class PluginMessageHandler implements PluginMessageListener {
             }
         });
         actionBarProgress.removePlayer(playerId);
+    }
+
+    public void shutdown() {
+        invalidMessageWarnings.clear();
+        inboundMessageLimiter.clear();
+        downloadProgress.forEach((sessionId, progress) -> {
+            if (downloadProgress.remove(sessionId, progress)) {
+                progress.cancel();
+            }
+        });
     }
 
     private void completeDownloadProgress(String sessionId) {

--- a/src/main/java/dev/twme/worldeditsync/paper/s3/S3StorageManager.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/s3/S3StorageManager.java
@@ -51,14 +51,9 @@ public class S3StorageManager {
      * Returns the ready client, or null on failure.
      */
     public MinioClient initialize() {
+        MinioClient client = null;
         try {
-            MinioClient.Builder builder = MinioClient.builder()
-                    .endpoint(endpoint)
-                    .credentials(accessKey, secretKey);
-            if (region != null && !region.isBlank()) {
-                builder.region(region);
-            }
-            MinioClient client = builder.build();
+            client = createClient();
             client.setTimeout(10_000L, 30_000L, 30_000L);
             boolean exists = client.bucketExists(BucketExistsArgs.builder().bucket(bucket).build());
             if (!exists) {
@@ -74,9 +69,26 @@ public class S3StorageManager {
             }
             return client;
         } catch (Exception e) {
+            if (client != null) {
+                try {
+                    client.close();
+                } catch (Exception closeError) {
+                    e.addSuppressed(closeError);
+                }
+            }
             logger.severe("Failed to initialize S3: " + e.getMessage());
             return null;
         }
+    }
+
+    protected MinioClient createClient() {
+        MinioClient.Builder builder = MinioClient.builder()
+                .endpoint(endpoint)
+                .credentials(accessKey, secretKey);
+        if (region != null && !region.isBlank()) {
+            builder.region(region);
+        }
+        return builder.build();
     }
 
     /**

--- a/src/main/java/dev/twme/worldeditsync/paper/storage/RedisClipboardStorage.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/storage/RedisClipboardStorage.java
@@ -240,7 +240,7 @@ public final class RedisClipboardStorage implements ClipboardStorage {
                 BinaryJedisPubSub listener = new BinaryJedisPubSub() {
                     @Override
                     public void onMessage(byte[] channel, byte[] message) {
-                        if (subscriberRunning.get()) {
+                        if (subscriberRunning.get() && isCanonicalUuid(message)) {
                             try {
                                 updateListener.accept(string(message));
                             } catch (RuntimeException e) {
@@ -312,5 +312,25 @@ public final class RedisClipboardStorage implements ClipboardStorage {
 
     private static String string(byte[] value) {
         return new String(value, StandardCharsets.UTF_8);
+    }
+
+    private static boolean isCanonicalUuid(byte[] value) {
+        if (value == null || value.length != 36) {
+            return false;
+        }
+        for (int index = 0; index < value.length; index++) {
+            byte character = value[index];
+            boolean hyphenPosition = index == 8 || index == 13 || index == 18 || index == 23;
+            if (hyphenPosition) {
+                if (character != '-') {
+                    return false;
+                }
+            } else if (!((character >= '0' && character <= '9')
+                    || (character >= 'a' && character <= 'f')
+                    || (character >= 'A' && character <= 'F'))) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/dev/twme/worldeditsync/paper/storage/S3ClipboardStorage.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/storage/S3ClipboardStorage.java
@@ -45,8 +45,12 @@ public final class S3ClipboardStorage implements ClipboardStorage {
     }
 
     @Override
-    public void close() {
+    public void close() throws Exception {
+        MinioClient activeClient = client;
         client = null;
+        if (activeClient != null) {
+            activeClient.close();
+        }
     }
 
     private MinioClient requireClient() {

--- a/src/main/java/dev/twme/worldeditsync/paper/sync/ProxySyncEngine.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/sync/ProxySyncEngine.java
@@ -37,6 +37,7 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
     private final ActionBarProgress actionBarProgress;
     private final Logger logger;
     private final ConcurrentHashMap<String, PendingUpload> pendingUploads = new ConcurrentHashMap<>();
+    private final AtomicBoolean running = new AtomicBoolean();
 
     private PluginMessageHandler messageHandler;
 
@@ -56,6 +57,7 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
 
     @Override
     public void start() {
+        running.set(true);
         plugin.getServer().getMessenger().registerOutgoingPluginChannel(plugin, Constants.CHANNEL);
         messageHandler = new PluginMessageHandler(
                 plugin, clipboardManager, clipboardSerializer, cipher, pluginMessageCodec,
@@ -66,10 +68,18 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
 
     @Override
     public void shutdown() {
+        running.set(false);
         plugin.getServer().getMessenger().unregisterOutgoingPluginChannel(plugin, Constants.CHANNEL);
         plugin.getServer().getMessenger().unregisterIncomingPluginChannel(plugin, Constants.CHANNEL);
-        pendingUploads.values().forEach(upload -> upload.progress.cancel());
-        pendingUploads.clear();
+        if (messageHandler != null) {
+            messageHandler.shutdown();
+        }
+        pendingUploads.forEach((sessionId, upload) -> {
+            if (pendingUploads.remove(sessionId, upload)) {
+                clipboardManager.releaseTransferMemory(upload.payload.length);
+                upload.progress.cancel();
+            }
+        });
         logger.info("Proxy sync engine shut down.");
     }
 
@@ -78,7 +88,8 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
         UUID playerId = player.getUniqueId();
         Object playerToken = clipboardManager.getPlayerToken(playerId);
 
-        if (!player.isOnline()
+        if (!running.get()
+                || !player.isOnline()
                 || !clipboardManager.isTracked(playerId)
                 || !ProtocolValidation.isSha256(hash)) {
             return;
@@ -93,10 +104,20 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
             return;
         }
 
+        int reservedBytes = Math.toIntExact((long) data.length
+                + (cipher.isEnabled() ? MessageCipher.ENCRYPTION_OVERHEAD_BYTES : 0L));
+        if (!clipboardManager.tryReserveTransferMemory(reservedBytes)) {
+            logger.warning("Clipboard upload is waiting because the transfer memory limit was reached for "
+                    + player.getName());
+            clipboardManager.forceSetState(playerId, SyncState.IDLE);
+            return;
+        }
+
         byte[] payload;
         try {
             payload = cipher.encrypt(data);
         } catch (Exception e) {
+            clipboardManager.releaseTransferMemory(reservedBytes);
             logger.warning("Clipboard encryption failed for " + player.getName() + ": " + e.getMessage());
             if (clipboardManager.isCurrentPlayerToken(playerId, playerToken)) {
                 clipboardManager.forgetClipboard(playerId);
@@ -105,9 +126,18 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
             return;
         }
 
-        if (!player.isOnline()
+        if (payload.length != reservedBytes) {
+            clipboardManager.releaseTransferMemory(reservedBytes);
+            logger.warning("Clipboard encryption produced an unexpected size for " + player.getName());
+            clipboardManager.forceSetState(playerId, SyncState.IDLE);
+            return;
+        }
+
+        if (!running.get()
+                || !player.isOnline()
                 || !clipboardManager.isCurrentPlayerToken(playerId, playerToken)
                 || clipboardManager.getState(playerId) != SyncState.UPLOADING) {
+            clipboardManager.releaseTransferMemory(payload.length);
             return;
         }
 
@@ -117,29 +147,41 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
 
         clipboardManager.setActiveSessionId(playerId, sessionId);
         ProgressHandle progress = actionBarProgress.begin(player, Operation.UPLOAD);
-        pendingUploads.put(sessionId,
-                new PendingUpload(playerId, payload, totalChunks, hash, progress));
+        PendingUpload pendingUpload = new PendingUpload(
+                playerId, payload, totalChunks, hash, progress);
+        pendingUploads.put(sessionId, pendingUpload);
 
-        if (!player.isOnline()
+        if (!running.get()
+                || !player.isOnline()
                 || !clipboardManager.isCurrentPlayerToken(playerId, playerToken)
                 || clipboardManager.getState(playerId) != SyncState.UPLOADING) {
-            pendingUploads.remove(sessionId);
-            progress.cancel();
+            if (pendingUploads.remove(sessionId, pendingUpload)) {
+                clipboardManager.releaseTransferMemory(payload.length);
+                progress.cancel();
+            }
             return;
         }
 
         byte[] beginMsg = pluginMessageCodec.encode(
                 ProtocolCodec.encodeUploadBegin(sessionId, payload.length, totalChunks, hash));
-        SchedulerUtil.runOnEntityThread(plugin, player, () -> {
-            if (player.isOnline() && sessionId.equals(clipboardManager.getActiveSessionId(playerId))) {
-                player.sendPluginMessage(plugin, Constants.CHANNEL, beginMsg);
+        try {
+            Object beginTask = SchedulerUtil.runOnEntityThread(plugin, player, () -> {
+                if (player.isOnline() && sessionId.equals(clipboardManager.getActiveSessionId(playerId))) {
+                    player.sendPluginMessage(plugin, Constants.CHANNEL, beginMsg);
+                }
+            });
+            Object timeoutTask = SchedulerUtil.runDelayedAsync(
+                    plugin,
+                    () -> timeoutUpload(player, sessionId),
+                    transferConfig.getSessionTimeoutMs());
+            if (beginTask == null || timeoutTask == null) {
+                failUpload(pendingUpload, sessionId);
+                return;
             }
-        });
-
-        SchedulerUtil.runDelayedAsync(
-                plugin,
-                () -> timeoutUpload(player, sessionId),
-                transferConfig.getSessionTimeoutMs());
+        } catch (RuntimeException e) {
+            failUpload(pendingUpload, sessionId);
+            return;
+        }
         logger.info("Clipboard upload started for " + player.getName()
                 + " (session: " + sessionId + ", " + data.length + " bytes)");
     }
@@ -160,11 +202,19 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
     }
 
     private void sendChunks(Player player, String sessionId, PendingUpload upload) {
-        SchedulerUtil.runOnEntityThread(plugin, player, () -> pumpUpload(player, sessionId, upload));
+        try {
+            if (SchedulerUtil.runOnEntityThread(
+                    plugin, player, () -> pumpUpload(player, sessionId, upload)) == null) {
+                failUpload(upload, sessionId);
+            }
+        } catch (RuntimeException e) {
+            failUpload(upload, sessionId);
+        }
     }
 
     private void pumpUpload(Player player, String sessionId, PendingUpload upload) {
-        if (!player.isOnline()
+        if (!running.get()
+                || !player.isOnline()
                 || !sessionId.equals(clipboardManager.getActiveSessionId(upload.playerId))) {
             failUpload(upload, sessionId);
             return;
@@ -188,8 +238,11 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
             upload.progress.update((double) upload.nextChunkIndex / upload.totalChunks);
 
             if (upload.nextChunkIndex < upload.totalChunks) {
-                SchedulerUtil.runDelayedOnEntityThread(
-                        plugin, player, () -> pumpUpload(player, sessionId, upload), pumpDelayTicks());
+                if (SchedulerUtil.runDelayedOnEntityThread(
+                        plugin, player, () -> pumpUpload(player, sessionId, upload),
+                        pumpDelayTicks()) == null) {
+                    failUpload(upload, sessionId);
+                }
             }
         } catch (Exception e) {
             logger.warning("Clipboard upload failed for " + player.getName() + ": " + e.getMessage());
@@ -220,6 +273,7 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
         if (!pendingUploads.remove(sessionId, upload)) {
             return;
         }
+        clipboardManager.releaseTransferMemory(upload.payload.length);
         upload.progress.complete();
         if (sessionId.equals(clipboardManager.getActiveSessionId(playerId))) {
             clipboardManager.setLocalHash(playerId, upload.hash);
@@ -262,10 +316,16 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
             return;
         }
         if (!upload.isExpired(transferConfig.getSessionTimeoutMs())) {
-            SchedulerUtil.runDelayedAsync(
-                    plugin,
-                    () -> timeoutUpload(player, sessionId),
-                    transferConfig.getSessionTimeoutMs());
+            try {
+                if (SchedulerUtil.runDelayedAsync(
+                        plugin,
+                        () -> timeoutUpload(player, sessionId),
+                        transferConfig.getSessionTimeoutMs()) == null) {
+                    failUpload(upload, sessionId);
+                }
+            } catch (RuntimeException e) {
+                failUpload(upload, sessionId);
+            }
             return;
         }
         if (!failUpload(upload, sessionId)) {
@@ -285,6 +345,7 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
         if (!pendingUploads.remove(sessionId, upload)) {
             return false;
         }
+        clipboardManager.releaseTransferMemory(upload.payload.length);
         upload.progress.fail();
         if (sessionId.equals(clipboardManager.getActiveSessionId(upload.playerId))) {
             clipboardManager.clearActiveSession(upload.playerId);
@@ -296,6 +357,9 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
 
     @Override
     public void onPlayerJoinServer(Player player) {
+        if (!running.get()) {
+            return;
+        }
         UUID playerId = player.getUniqueId();
         String requestId = UUID.randomUUID().toString();
         clipboardManager.initPlayer(playerId);
@@ -304,6 +368,9 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
     }
 
     private void sendInitialSyncRequest(Player player, String requestId, int attempt) {
+        if (!running.get()) {
+            return;
+        }
         SchedulerUtil.runOnEntityThread(plugin, player, () -> {
             UUID playerId = player.getUniqueId();
             if (!player.isOnline()
@@ -339,12 +406,16 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
         if (state == SyncState.UPLOADING || state == SyncState.DOWNLOADING) {
             String sessionId = clipboardManager.getActiveSessionId(playerId);
             if (sessionId != null) {
-                pendingUploads.remove(sessionId);
+                PendingUpload removed = pendingUploads.remove(sessionId);
+                if (removed != null) {
+                    clipboardManager.releaseTransferMemory(removed.payload.length);
+                    removed.progress.cancel();
+                }
                 byte[] cancelMsg = pluginMessageCodec.encode(
                         ProtocolCodec.encodeCancel(sessionId, "player_quit"));
                 try {
                     player.sendPluginMessage(plugin, Constants.CHANNEL, cancelMsg);
-                } catch (Exception ignored) {
+                } catch (RuntimeException ignored) {
                     // Player might already be disconnected
                 }
             }
@@ -385,7 +456,8 @@ public class ProxySyncEngine implements SyncEngine, UploadSessionListener {
         }
 
         private boolean isExpired(long timeoutMs) {
-            return System.currentTimeMillis() - lastActivityAt >= timeoutMs;
+            long now = System.currentTimeMillis();
+            return now < lastActivityAt || now - lastActivityAt >= timeoutMs;
         }
     }
 }

--- a/src/main/java/dev/twme/worldeditsync/paper/sync/StorageSyncEngine.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/sync/StorageSyncEngine.java
@@ -1,6 +1,8 @@
 package dev.twme.worldeditsync.paper.sync;
 
 import java.util.UUID;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -43,6 +45,7 @@ public class StorageSyncEngine implements SyncEngine {
     private final AtomicBoolean running = new AtomicBoolean();
     private final AtomicBoolean ready = new AtomicBoolean();
     private final AtomicBoolean scanPending = new AtomicBoolean();
+    private final Set<UUID> inspectionsPending = ConcurrentHashMap.newKeySet();
     private final AtomicLong lastErrorLog = new AtomicLong();
 
     private boolean initializationInProgress;
@@ -80,6 +83,11 @@ public class StorageSyncEngine implements SyncEngine {
             initializationInProgress = true;
             try {
                 initializationTask = SchedulerUtil.runAsync(plugin, this::initializeConnection);
+                if (initializationTask == null) {
+                    initializationInProgress = false;
+                    logger.warning("Could not schedule " + storage.description()
+                            + " initialization.");
+                }
             } catch (RuntimeException e) {
                 initializationInProgress = false;
                 throw e;
@@ -109,7 +117,7 @@ public class StorageSyncEngine implements SyncEngine {
             } else {
                 initializationTask = SchedulerUtil.runDelayedAsync(
                         plugin, this::initializeAsync, INITIALIZATION_RETRY_MS);
-                retrying = true;
+                retrying = initializationTask != null;
             }
         }
         if (closeStorage) {
@@ -139,6 +147,9 @@ public class StorageSyncEngine implements SyncEngine {
                 this::checkAllPlayers,
                 transferConfig.getWatcherInitialDelayTicks(),
                 checkIntervalTicks);
+        if (watcherTask == null) {
+            logger.warning("Could not schedule " + storage.description() + " clipboard watcher.");
+        }
     }
 
     @Override
@@ -155,6 +166,7 @@ public class StorageSyncEngine implements SyncEngine {
         }
         SchedulerUtil.cancelTask(pendingInitialization);
         SchedulerUtil.cancelTask(activeWatcher);
+        inspectionsPending.clear();
         try {
             storage.close();
         } catch (Exception e) {
@@ -186,9 +198,12 @@ public class StorageSyncEngine implements SyncEngine {
         String playerName = player.getName();
         ProgressHandle progress = actionBarProgress.begin(player, Operation.UPLOAD);
         try {
-            SchedulerUtil.runAsync(plugin,
+            if (SchedulerUtil.runAsync(plugin,
                     () -> uploadSerializedClipboard(
-                            playerId, playerToken, playerName, data, hash, progress));
+                            playerId, playerToken, playerName, data, hash, progress)) == null) {
+                progress.fail();
+                finishWorker(playerId, playerToken);
+            }
         } catch (RuntimeException e) {
             progress.fail();
             finishWorker(playerId, playerToken);
@@ -203,6 +218,7 @@ public class StorageSyncEngine implements SyncEngine {
 
     @Override
     public void onPlayerQuit(Player player) {
+        inspectionsPending.remove(player.getUniqueId());
         actionBarProgress.removePlayer(player.getUniqueId());
         clipboardManager.removePlayer(player.getUniqueId());
     }
@@ -211,15 +227,24 @@ public class StorageSyncEngine implements SyncEngine {
         if (!ready.get() || !scanPending.compareAndSet(false, true)) {
             return;
         }
-        SchedulerUtil.runOnGlobalThread(plugin, () -> {
-            try {
-                for (Player player : plugin.getServer().getOnlinePlayers()) {
-                    SchedulerUtil.runOnEntityThread(plugin, player, () -> inspectPlayer(player));
+        try {
+            if (SchedulerUtil.runOnGlobalThread(plugin, () -> {
+                try {
+                    if (!running.get() || !ready.get()) {
+                        return;
+                    }
+                    for (Player player : plugin.getServer().getOnlinePlayers()) {
+                        queueInspection(player);
+                    }
+                } finally {
+                    scanPending.set(false);
                 }
-            } finally {
+            }) == null) {
                 scanPending.set(false);
             }
-        });
+        } catch (RuntimeException e) {
+            scanPending.set(false);
+        }
     }
 
     private void onStorageUpdate(String playerId) {
@@ -232,17 +257,60 @@ public class StorageSyncEngine implements SyncEngine {
         } catch (IllegalArgumentException ignored) {
             return;
         }
-        SchedulerUtil.runOnGlobalThread(plugin, () -> {
-            Player player = plugin.getServer().getPlayer(playerUuid);
-            if (player != null && player.isOnline()) {
-                SchedulerUtil.runOnEntityThread(plugin, player, () -> inspectPlayer(player));
+        if (!inspectionsPending.add(playerUuid)) {
+            return;
+        }
+        try {
+            if (SchedulerUtil.runOnGlobalThread(plugin, () -> {
+                if (!running.get() || !ready.get()) {
+                    inspectionsPending.remove(playerUuid);
+                    return;
+                }
+                Player player = plugin.getServer().getPlayer(playerUuid);
+                if (player == null || !player.isOnline()) {
+                    inspectionsPending.remove(playerUuid);
+                    return;
+                }
+                scheduleReservedInspection(player);
+            }) == null) {
+                inspectionsPending.remove(playerUuid);
             }
-        });
+        } catch (RuntimeException e) {
+            inspectionsPending.remove(playerUuid);
+        }
+    }
+
+    private void queueInspection(Player player) {
+        if (!running.get() || !ready.get()) {
+            return;
+        }
+        UUID playerId = player.getUniqueId();
+        if (inspectionsPending.add(playerId)) {
+            scheduleReservedInspection(player);
+        }
+    }
+
+    private void scheduleReservedInspection(Player player) {
+        UUID playerId = player.getUniqueId();
+        try {
+            if (SchedulerUtil.runOnEntityThread(plugin, player, () -> {
+                try {
+                    inspectPlayer(player);
+                } finally {
+                    inspectionsPending.remove(playerId);
+                }
+            }) == null) {
+                inspectionsPending.remove(playerId);
+            }
+        } catch (RuntimeException e) {
+            inspectionsPending.remove(playerId);
+        }
     }
 
     private void inspectPlayer(Player player) {
         UUID playerId = player.getUniqueId();
-        if (!player.isOnline() || !player.hasPermission("worldeditsync.sync")) {
+        if (!running.get() || !ready.get()
+                || !player.isOnline() || !player.hasPermission("worldeditsync.sync")) {
             return;
         }
         if (!clipboardManager.isTracked(playerId)) {
@@ -284,9 +352,12 @@ public class StorageSyncEngine implements SyncEngine {
         }
 
         try {
-            SchedulerUtil.runAsync(plugin,
+            if (SchedulerUtil.runAsync(plugin,
                     () -> synchronizePlayer(
-                            player, playerId, playerToken, playerName, expectedClipboard));
+                            player, playerId, playerToken, playerName, expectedClipboard)) == null) {
+                workerSlots.release();
+                resetCheck(playerId, playerToken);
+            }
         } catch (RuntimeException e) {
             workerSlots.release();
             resetCheck(playerId, playerToken);
@@ -323,10 +394,16 @@ public class StorageSyncEngine implements SyncEngine {
             if (clipboard == null) {
                 return;
             }
+            if (remote.exists() && remote.hash().equalsIgnoreCase(localHash)
+                    && clipboardManager.isSerializedClipboard(playerId, clipboard)) {
+                return;
+            }
 
             byte[] serialized;
             try {
-                serialized = clipboardSerializer.serialize(clipboard);
+                serialized = clipboardSerializer.serialize(
+                        clipboard, transferConfig.getMaxClipboardSize(),
+                        transferConfig.getMaxClipboardBlocks());
             } catch (Exception e) {
                 callbackScheduled = scheduleEntityContinuation(
                         player, playerId, playerToken,
@@ -340,6 +417,7 @@ public class StorageSyncEngine implements SyncEngine {
                 return;
             }
             String hash = HashUtil.sha256Hex(serialized);
+            clipboardManager.markSerializedClipboard(playerId, clipboard, hash);
             if (remote.exists() && hash.equalsIgnoreCase(localHash)) {
                 return;
             }
@@ -364,6 +442,7 @@ public class StorageSyncEngine implements SyncEngine {
                                  Clipboard expectedClipboard, byte[] serialized, String hash) {
         if (!isActiveCheck(player, playerId, playerToken)
                 || clipboardSerializer.getPlayerClipboard(player) != expectedClipboard) {
+            clipboardManager.clearSerializedClipboard(playerId, expectedClipboard);
             resetCheck(playerId, playerToken);
             return;
         }
@@ -379,9 +458,12 @@ public class StorageSyncEngine implements SyncEngine {
 
         ProgressHandle progress = actionBarProgress.begin(player, Operation.UPLOAD);
         try {
-            SchedulerUtil.runAsync(plugin,
+            if (SchedulerUtil.runAsync(plugin,
                     () -> uploadSerializedClipboard(
-                            playerId, playerToken, playerName, serialized, hash, progress));
+                            playerId, playerToken, playerName, serialized, hash, progress)) == null) {
+                progress.fail();
+                finishWorker(playerId, playerToken);
+            }
         } catch (RuntimeException e) {
             progress.fail();
             finishWorker(playerId, playerToken);
@@ -420,6 +502,7 @@ public class StorageSyncEngine implements SyncEngine {
                                             Exception exception) {
         boolean clipboardWasReplaced = clipboardSerializer.getPlayerClipboard(player)
                 != expectedClipboard;
+        clipboardManager.clearSerializedClipboard(playerId, expectedClipboard);
         if (!clipboardWasReplaced && clipboardManager.isCurrentPlayerToken(playerId, playerToken)) {
             logOperationalFailure(storage.description() + " clipboard serialization failed for "
                     + playerName, exception);
@@ -445,7 +528,9 @@ public class StorageSyncEngine implements SyncEngine {
             if (!actualHash.equalsIgnoreCase(remote.hash())) {
                 throw new SecurityException(storage.description() + " clipboard hash mismatch");
             }
-            Clipboard downloaded = clipboardSerializer.deserialize(data);
+            Clipboard downloaded = clipboardSerializer.deserialize(
+                    data, transferConfig.getMaxClipboardSize(),
+                    transferConfig.getMaxClipboardBlocks());
             boolean scheduled = scheduleEntityContinuation(player, playerId, playerToken, () -> {
                 if (!running.get()
                         || !player.isOnline()
@@ -462,6 +547,7 @@ public class StorageSyncEngine implements SyncEngine {
                 try {
                     clipboardSerializer.setPlayerClipboard(player, downloaded);
                     clipboardManager.setLocalHash(playerId, actualHash);
+                    clipboardManager.markSerializedClipboard(playerId, downloaded, actualHash);
                     progress.complete();
                     logger.info("Clipboard synced from " + storage.description() + " for " + playerName);
                 } catch (Exception e) {

--- a/src/main/java/dev/twme/worldeditsync/paper/update/UpdateChecker.java
+++ b/src/main/java/dev/twme/worldeditsync/paper/update/UpdateChecker.java
@@ -1,11 +1,10 @@
 package dev.twme.worldeditsync.paper.update;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.time.Duration;
+import java.nio.charset.StandardCharsets;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -14,7 +13,10 @@ import dev.twme.worldeditsync.paper.util.SchedulerUtil;
 public class UpdateChecker {
 
     private static final String SPIGOT_RESOURCE_ID = "121682";
-    private static final String API_URL = "https://api.spigotmc.org/legacy/update.php?resource=" + SPIGOT_RESOURCE_ID;
+    private static final String API_URL = "https://api.spigotmc.org/legacy/update.php?resource="
+            + SPIGOT_RESOURCE_ID;
+    private static final int TIMEOUT_MS = 10_000;
+    private static final int MAX_RESPONSE_BYTES = 64;
 
     private final JavaPlugin plugin;
 
@@ -24,26 +26,38 @@ public class UpdateChecker {
 
     public void checkAsync() {
         SchedulerUtil.runAsync(plugin, () -> {
+            HttpURLConnection connection = null;
             try {
-                HttpClient client = HttpClient.newBuilder()
-                        .connectTimeout(Duration.ofSeconds(10))
-                        .build();
-                HttpRequest request = HttpRequest.newBuilder()
-                        .uri(URI.create(API_URL))
-                        .timeout(Duration.ofSeconds(10))
-                        .GET()
-                        .build();
-                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+                connection = (HttpURLConnection) URI.create(API_URL).toURL().openConnection();
+                connection.setConnectTimeout(TIMEOUT_MS);
+                connection.setReadTimeout(TIMEOUT_MS);
+                connection.setRequestMethod("GET");
+                int status = connection.getResponseCode();
+                if (status < 200 || status >= 300) {
+                    throw new IOException("Update service returned HTTP " + status);
+                }
+                byte[] response;
+                try (InputStream input = connection.getInputStream()) {
+                    response = input.readNBytes(MAX_RESPONSE_BYTES + 1);
+                }
+                if (response.length == 0 || response.length > MAX_RESPONSE_BYTES) {
+                    throw new IOException("Update service returned an invalid response");
+                }
 
-                String latestVersion = response.body().trim();
+                String latestVersion = new String(response, StandardCharsets.UTF_8).trim();
                 String currentVersion = plugin.getDescription().getVersion();
                 if (!currentVersion.equals(latestVersion)) {
                     plugin.getLogger().info("A new version is available: " + latestVersion
                             + " (current: " + currentVersion + ")");
-                    plugin.getLogger().info("Download: https://www.spigotmc.org/resources/" + SPIGOT_RESOURCE_ID);
+                    plugin.getLogger().info("Download: https://www.spigotmc.org/resources/"
+                            + SPIGOT_RESOURCE_ID);
                 }
-            } catch (IOException | InterruptedException e) {
+            } catch (IOException e) {
                 plugin.getLogger().fine("Could not check for updates: " + e.getMessage());
+            } finally {
+                if (connection != null) {
+                    connection.disconnect();
+                }
             }
         });
     }

--- a/src/main/java/dev/twme/worldeditsync/velocity/WorldEditSyncVelocity.java
+++ b/src/main/java/dev/twme/worldeditsync/velocity/WorldEditSyncVelocity.java
@@ -18,6 +18,7 @@ import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.ServerConnection;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
+import com.velocitypowered.api.scheduler.ScheduledTask;
 
 import dev.twme.worldeditsync.common.Constants;
 import dev.twme.worldeditsync.common.crypto.MessageCipher;
@@ -39,6 +40,7 @@ public class WorldEditSyncVelocity {
     private ChannelIdentifier channelId;
     private MessageHandler messageHandler;
     private VelocityConfig config;
+    private ScheduledTask cleanupTask;
 
     @Inject
     public WorldEditSyncVelocity(ProxyServer server, Logger logger, @DataDirectory Path dataDirectory) {
@@ -63,7 +65,7 @@ public class WorldEditSyncVelocity {
             return;
         }
 
-        store = new ClipboardStore();
+        store = new ClipboardStore(config.getMemoryLimitBytes());
 
         MessageCipher cipher = new MessageCipher(config.getToken());
         if (cipher.isEnabled()) {
@@ -73,13 +75,13 @@ public class WorldEditSyncVelocity {
         }
 
         // Initialize handler
-        PluginMessageCodec pluginMessageCodec = new PluginMessageCodec(config.getToken());
+        PluginMessageCodec pluginMessageCodec = PluginMessageCodec.forProxy(config.getToken());
         messageHandler = new MessageHandler(this, server, store, channelId,
                 config.getChunkSize(), config.getMaxClipboardSize(), config.getChunkSendDelayMs(),
                 config.getSessionTimeoutMs(), pluginMessageCodec, logger);
 
         // Schedule cleanup
-        server.getScheduler().buildTask(this, () -> {
+        cleanupTask = server.getScheduler().buildTask(this, () -> {
             store.cleanupExpiredSessions(config.getSessionTimeoutMs());
             store.cleanupExpiredClipboards(config.getClipboardTtlMinutes());
         }).repeat(Duration.ofMinutes(2)).schedule();
@@ -91,6 +93,13 @@ public class WorldEditSyncVelocity {
     public void onProxyShutdown(ProxyShutdownEvent event) {
         if (channelId != null) {
             server.getChannelRegistrar().unregister(channelId);
+        }
+        if (cleanupTask != null) {
+            cleanupTask.cancel();
+            cleanupTask = null;
+        }
+        if (messageHandler != null) {
+            messageHandler.shutdown();
         }
         if (store != null) {
             store.shutdown();

--- a/src/main/java/dev/twme/worldeditsync/velocity/config/VelocityConfig.java
+++ b/src/main/java/dev/twme/worldeditsync/velocity/config/VelocityConfig.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.yaml.snakeyaml.Yaml;
 import dev.twme.worldeditsync.common.Constants;
+import dev.twme.worldeditsync.common.crypto.MessageCipher;
 
 public class VelocityConfig {
 
@@ -18,6 +19,7 @@ public class VelocityConfig {
     private int chunkSize = 30_000;
     private long chunkSendDelayMs = 5;
     private int maxClipboardSize = 52_428_800;
+    private long memoryLimitBytes = Constants.DEFAULT_TRANSFER_MEMORY_LIMIT_BYTES;
 
     public void load(Path dataDirectory, Logger logger) {
         try {
@@ -48,10 +50,18 @@ public class VelocityConfig {
                     chunkSize = getInt(transfer, "chunk-size", chunkSize);
                     chunkSendDelayMs = getLong(transfer, "chunk-send-delay-ms", chunkSendDelayMs);
                     maxClipboardSize = getInt(transfer, "max-clipboard-size", maxClipboardSize);
+                    memoryLimitBytes = getLong(
+                            transfer, "memory-limit-bytes", memoryLimitBytes);
                 }
-                chunkSize = Math.max(1, Math.min(Constants.MAX_CHUNK_SIZE, chunkSize));
+                chunkSize = Math.max(Constants.MIN_CHUNK_SIZE,
+                        Math.min(Constants.MAX_CHUNK_SIZE, chunkSize));
                 maxClipboardSize = Math.max(1, Math.min(
                         Constants.ABSOLUTE_MAX_CLIPBOARD_SIZE, maxClipboardSize));
+                memoryLimitBytes = Math.max(
+                        (long) maxClipboardSize + MessageCipher.ENCRYPTION_OVERHEAD_BYTES,
+                        Math.max(Constants.MIN_TRANSFER_MEMORY_LIMIT_BYTES,
+                                Math.min(Constants.MAX_TRANSFER_MEMORY_LIMIT_BYTES,
+                                        memoryLimitBytes)));
                 chunkSendDelayMs = Math.max(0L, Math.min(1_000L, chunkSendDelayMs));
                 sessionTimeoutMs = Math.max(5_000L, sessionTimeoutMs);
                 clipboardTtlMinutes = Math.max(0L, clipboardTtlMinutes);
@@ -100,5 +110,9 @@ public class VelocityConfig {
 
     public int getMaxClipboardSize() {
         return maxClipboardSize;
+    }
+
+    public long getMemoryLimitBytes() {
+        return memoryLimitBytes;
     }
 }

--- a/src/main/java/dev/twme/worldeditsync/velocity/handler/MessageHandler.java
+++ b/src/main/java/dev/twme/worldeditsync/velocity/handler/MessageHandler.java
@@ -42,6 +42,7 @@ public class MessageHandler {
     private final InboundMessageLimiter inboundMessageLimiter = new InboundMessageLimiter();
     private final ConcurrentHashMap<UUID, Long> invalidMessageWarnings = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<UUID, String> pendingSyncRequests = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, String> activeDownloads = new ConcurrentHashMap<>();
 
     public MessageHandler(Object plugin, ProxyServer server, ClipboardStore store,
                           ChannelIdentifier channelId, int chunkSize, int maxClipboardSize,
@@ -67,6 +68,7 @@ public class MessageHandler {
         }
         ParsedMessage msg = pluginMessageCodec.decode(data);
         if (msg == null) {
+            inboundMessageLimiter.recordInvalidMessage(player.getUniqueId());
             warnInvalidMessage(player, "Invalid protocol message from ");
             return;
         }
@@ -107,7 +109,8 @@ public class MessageHandler {
             return;
         }
 
-        TransferSession session = new TransferSession(sessionId, totalChunks, totalBytes, hash);
+        TransferSession session = new TransferSession(
+                sessionId, totalChunks, totalBytes, chunkSize, hash);
         if (!store.addUploadSession(sessionId, player.getUniqueId(), session)) {
             sendToPlayer(player, ProtocolCodec.encodeCancel(sessionId, "duplicate_session"));
             return;
@@ -160,7 +163,7 @@ public class MessageHandler {
 
         try {
             session.addChunk(chunkIndex, chunkData);
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | IllegalStateException e) {
             rejectUpload(player, sessionId, e.getMessage());
             return;
         }
@@ -176,9 +179,7 @@ public class MessageHandler {
         String playerName = player.getUsername();
         server.getScheduler().buildTask(plugin, () -> {
             try {
-                byte[] assembled = session.assemble();
-                if (!store.completeUploadSession(
-                        sessionId, playerId, session, assembled, session.getExpectedHash())) {
+                if (!store.completeUploadSession(sessionId, playerId, session)) {
                     logger.debug("Ignoring stale completed upload for " + playerName
                             + " (session: " + sessionId + ")");
                     return;
@@ -290,6 +291,7 @@ public class MessageHandler {
         byte[] data = payload.getData();
         int totalChunks = (int) Math.ceil((double) data.length / chunkSize);
         String sessionId = UUID.randomUUID().toString();
+        activeDownloads.put(player.getUniqueId(), sessionId);
 
         byte[] beginMsg = ProtocolCodec.encodeDownloadBegin(
                 requestId, sessionId, data.length, totalChunks, payload.getHash());
@@ -301,6 +303,7 @@ public class MessageHandler {
                                       String sessionId, int totalChunks, int nextChunk) {
         server.getScheduler().buildTask(plugin, () -> {
             if (!player.isActive()
+                    || !sessionId.equals(activeDownloads.get(player.getUniqueId()))
                     || player.getCurrentServer().filter(destination::equals).isEmpty()) {
                 return;
             }
@@ -342,6 +345,7 @@ public class MessageHandler {
             logger.warn("Malformed download acknowledgement from " + player.getUsername());
             return;
         }
+        activeDownloads.remove(player.getUniqueId(), sessionId);
         logger.debug("Download acknowledged by " + player.getUsername() + " session: " + sessionId);
     }
 
@@ -357,6 +361,7 @@ public class MessageHandler {
         }
 
         store.removeUploadSession(sessionId, player.getUniqueId());
+        activeDownloads.remove(player.getUniqueId(), sessionId);
         logger.debug("Transfer cancelled by " + player.getUsername() + ": " + reason);
     }
 
@@ -373,7 +378,15 @@ public class MessageHandler {
         pendingSyncRequests.remove(playerId);
         inboundMessageLimiter.remove(playerId);
         invalidMessageWarnings.remove(playerId);
+        activeDownloads.remove(playerId);
         store.removeIncompleteUploadSessionForOwner(playerId);
+    }
+
+    public void shutdown() {
+        pendingSyncRequests.clear();
+        activeDownloads.clear();
+        invalidMessageWarnings.clear();
+        inboundMessageLimiter.clear();
     }
 
     private void warnInvalidMessage(Player player, String prefix) {

--- a/src/main/java/dev/twme/worldeditsync/velocity/storage/ClipboardStore.java
+++ b/src/main/java/dev/twme/worldeditsync/velocity/storage/ClipboardStore.java
@@ -1,146 +1,15 @@
 package dev.twme.worldeditsync.velocity.storage;
 
-import dev.twme.worldeditsync.common.model.ClipboardPayload;
-import dev.twme.worldeditsync.common.protocol.TransferSession;
+import dev.twme.worldeditsync.common.storage.ProxyClipboardStore;
 
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
+/** Velocity-facing type for the shared, memory-bounded proxy store. */
+public class ClipboardStore extends ProxyClipboardStore {
 
-/**
- * Proxy-side clipboard storage for Velocity.
- * Stores encrypted clipboard data per player with TTL support.
- */
-public class ClipboardStore {
-
-    private final ConcurrentHashMap<UUID, ClipboardPayload> clipboards = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, TransferSession> uploadSessions = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, UUID> sessionOwners = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<UUID, String> ownerSessions = new ConcurrentHashMap<>();
-
-    // ── Clipboard storage ──
-
-    public void storeClipboard(UUID playerId, byte[] data, String hash) {
-        clipboards.put(playerId, new ClipboardPayload(data, hash));
+    public ClipboardStore() {
+        super();
     }
 
-    /** Commit only if this is still the player's current upload session. */
-    public synchronized boolean completeUploadSession(String sessionId, UUID playerId,
-                                                      TransferSession expectedSession,
-                                                      byte[] data, String hash) {
-        if (!sessionId.equals(ownerSessions.get(playerId))
-                || !playerId.equals(sessionOwners.get(sessionId))
-                || uploadSessions.get(sessionId) != expectedSession) {
-            return false;
-        }
-        clipboards.put(playerId, new ClipboardPayload(data, hash));
-        removeUploadSession(sessionId);
-        return true;
-    }
-
-    public ClipboardPayload getClipboard(UUID playerId) {
-        return clipboards.get(playerId);
-    }
-
-    public boolean hasClipboard(UUID playerId) {
-        return clipboards.containsKey(playerId);
-    }
-
-    // ── Upload session management ──
-
-    public synchronized boolean addUploadSession(String sessionId, UUID playerId, TransferSession session) {
-        if (uploadSessions.containsKey(sessionId)) {
-            return false;
-        }
-        String previousSession = ownerSessions.put(playerId, sessionId);
-        if (previousSession != null) {
-            uploadSessions.remove(previousSession);
-            sessionOwners.remove(previousSession);
-        }
-        uploadSessions.put(sessionId, session);
-        sessionOwners.put(sessionId, playerId);
-        return true;
-    }
-
-    public TransferSession getUploadSession(String sessionId) {
-        return uploadSessions.get(sessionId);
-    }
-
-    public UUID getSessionOwner(String sessionId) {
-        return sessionOwners.get(sessionId);
-    }
-
-    public synchronized void removeUploadSession(String sessionId) {
-        uploadSessions.remove(sessionId);
-        UUID owner = sessionOwners.remove(sessionId);
-        if (owner != null) {
-            ownerSessions.remove(owner, sessionId);
-        }
-    }
-
-    public synchronized boolean removeUploadSession(String sessionId, UUID expectedOwner) {
-        if (!expectedOwner.equals(sessionOwners.get(sessionId))) {
-            return false;
-        }
-        removeUploadSession(sessionId);
-        return true;
-    }
-
-    public synchronized boolean removeUploadSession(String sessionId, UUID expectedOwner,
-                                                    TransferSession expectedSession) {
-        if (uploadSessions.get(sessionId) != expectedSession) {
-            return false;
-        }
-        return removeUploadSession(sessionId, expectedOwner);
-    }
-
-    public boolean hasActiveUpload(UUID playerId) {
-        return ownerSessions.containsKey(playerId);
-    }
-
-    public synchronized TransferSession getUploadSessionForOwner(UUID playerId) {
-        String sessionId = ownerSessions.get(playerId);
-        return sessionId == null ? null : uploadSessions.get(sessionId);
-    }
-
-    public synchronized void removeUploadSessionForOwner(UUID playerId) {
-        String sessionId = ownerSessions.get(playerId);
-        if (sessionId != null) {
-            removeUploadSession(sessionId);
-        }
-    }
-
-    public synchronized void removeIncompleteUploadSessionForOwner(UUID playerId) {
-        String sessionId = ownerSessions.get(playerId);
-        TransferSession session = sessionId == null ? null : uploadSessions.get(sessionId);
-        if (session != null && !session.isComplete()) {
-            removeUploadSession(sessionId);
-        }
-    }
-
-    // ── Cleanup ──
-
-    public synchronized void cleanupExpiredSessions(long timeoutMs) {
-        uploadSessions.entrySet().removeIf(entry -> {
-            if (!entry.getValue().isComplete() && entry.getValue().isExpired(timeoutMs)) {
-                UUID owner = sessionOwners.remove(entry.getKey());
-                if (owner != null) {
-                    ownerSessions.remove(owner, entry.getKey());
-                }
-                return true;
-            }
-            return false;
-        });
-    }
-
-    public void cleanupExpiredClipboards(long ttlMinutes) {
-        if (ttlMinutes <= 0) return;
-        clipboards.entrySet().removeIf(entry -> entry.getValue().isExpired(ttlMinutes));
-    }
-
-    public synchronized void shutdown() {
-        clipboards.clear();
-        uploadSessions.clear();
-        sessionOwners.clear();
-        ownerSessions.clear();
+    public ClipboardStore(long maxMemoryBytes) {
+        super(maxMemoryBytes);
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -69,12 +69,14 @@ database:
 # Advanced transfer settings
 # ============================================================
 transfer:
-  # Size of each chunk in bytes (~30KB, must stay below 32KB plugin message limit)
+  # Size of each chunk in bytes (1024-30000; ~30KB is recommended)
   chunk-size: 30000
   # Transfer session timeout in milliseconds
   session-timeout-ms: 30000
   # Maximum clipboard size in bytes (default: 50MB)
   max-clipboard-size: 52428800
+  # Maximum number of blocks in one clipboard (default: 256 x 256 x 256)
+  max-clipboard-blocks: 16777216
   # Delay between sending chunks in milliseconds
   chunk-send-delay-ms: 5
   # Clipboard watcher interval in ticks (20 ticks = 1 second)
@@ -83,3 +85,6 @@ transfer:
   watcher-initial-delay-ticks: 40
   # How long to keep offline player clipboard data on proxy (in minutes, 0 = forever)
   clipboard-ttl-minutes: 60
+  # Maximum total bytes retained for in-progress transfers, and by a
+  # BungeeCord/Velocity proxy for stored clipboards. Oldest proxy data is evicted first.
+  memory-limit-bytes: 268435456

--- a/src/test/java/dev/twme/worldeditsync/bungeecord/handler/MessageHandlerTest.java
+++ b/src/test/java/dev/twme/worldeditsync/bungeecord/handler/MessageHandlerTest.java
@@ -41,16 +41,17 @@ public class MessageHandlerTest {
 
         ClipboardStore store = new ClipboardStore();
         store.storeClipboard(playerId, new byte[] {1, 2, 3}, hash);
-        PluginMessageCodec wireCodec = new PluginMessageCodec("test-token");
+        PluginMessageCodec paperCodec = PluginMessageCodec.forPaper("test-token");
+        PluginMessageCodec proxyCodec = PluginMessageCodec.forProxy("test-token");
         MessageHandler handler = new MessageHandler(
-                plugin, store, 30_000, 1024, 5, 30_000, wireCodec);
+                plugin, store, 30_000, 1024, 5, 30_000, proxyCodec);
 
         handler.handleMessage(player,
-                wireCodec.encode(ProtocolCodec.encodeSyncRequest(requestId)));
+                paperCodec.encode(ProtocolCodec.encodeSyncRequest(requestId)));
 
         ArgumentCaptor<byte[]> response = ArgumentCaptor.forClass(byte[].class);
         verify(backend).sendData(eq(Constants.CHANNEL), response.capture());
-        ProtocolCodec.ParsedMessage parsed = wireCodec.decode(response.getValue());
+        ProtocolCodec.ParsedMessage parsed = paperCodec.decode(response.getValue());
         assertNotNull(parsed);
         assertEquals(MessageType.SYNC_HASH, parsed.type());
         try (DataInputStream input = ProtocolCodec.payloadStream(parsed)) {

--- a/src/test/java/dev/twme/worldeditsync/common/protocol/InboundMessageLimiterTest.java
+++ b/src/test/java/dev/twme/worldeditsync/common/protocol/InboundMessageLimiterTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
 
@@ -31,5 +32,48 @@ public class InboundMessageLimiterTest {
         assertFalse(limiter.tryAcquire(first, -1));
         assertFalse(limiter.tryAcquire(first, Constants.MAX_PLUGIN_MESSAGE_SIZE + 1));
         assertTrue(limiter.tryAcquire(second, Constants.MAX_PLUGIN_MESSAGE_SIZE));
+    }
+
+    @Test
+    public void invalidMessageTemporarilyBlocksOnlyItsPlayer() {
+        AtomicLong clock = new AtomicLong(10_000L);
+        InboundMessageLimiter limiter = new InboundMessageLimiter(clock::get);
+        UUID attacker = UUID.randomUUID();
+        UUID legitimate = UUID.randomUUID();
+
+        limiter.recordInvalidMessage(attacker);
+
+        assertFalse(limiter.tryAcquire(attacker, 1));
+        assertTrue(limiter.tryAcquire(legitimate, 1));
+        clock.addAndGet(Constants.INVALID_MESSAGE_PLAYER_COOLDOWN_MS);
+        assertTrue(limiter.tryAcquire(attacker, 1));
+    }
+
+    @Test
+    public void aggregateInvalidTrafficTripsShortGlobalBreaker() {
+        AtomicLong clock = new AtomicLong(20_000L);
+        InboundMessageLimiter limiter = new InboundMessageLimiter(clock::get);
+        for (int i = 0; i <= Constants.MAX_INVALID_MESSAGES_PER_SECOND; i++) {
+            limiter.recordInvalidMessage(UUID.randomUUID());
+        }
+
+        assertFalse(limiter.tryAcquire(UUID.randomUUID(), 1));
+        clock.addAndGet(Constants.INVALID_MESSAGE_GLOBAL_COOLDOWN_MS);
+        assertTrue(limiter.tryAcquire(UUID.randomUUID(), 1));
+    }
+
+    @Test
+    public void clearDropsPlayerAndGlobalCircuitBreakerState() {
+        AtomicLong clock = new AtomicLong(30_000L);
+        InboundMessageLimiter limiter = new InboundMessageLimiter(clock::get);
+        UUID playerId = UUID.randomUUID();
+        for (int i = 0; i <= Constants.MAX_INVALID_MESSAGES_PER_SECOND; i++) {
+            limiter.recordInvalidMessage(UUID.randomUUID());
+        }
+        limiter.recordInvalidMessage(playerId);
+
+        limiter.clear();
+
+        assertTrue(limiter.tryAcquire(playerId, 1));
     }
 }

--- a/src/test/java/dev/twme/worldeditsync/common/protocol/PluginMessageCodecTest.java
+++ b/src/test/java/dev/twme/worldeditsync/common/protocol/PluginMessageCodecTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
 import java.io.DataInputStream;
+import java.util.Random;
 import java.util.UUID;
 
 import org.junit.Test;
@@ -14,29 +15,49 @@ public class PluginMessageCodecTest {
 
     @Test
     public void encryptsAndAuthenticatesEveryProtocolMessage() throws Exception {
-        PluginMessageCodec codec = new PluginMessageCodec("shared-token");
+        PluginMessageCodec paper = PluginMessageCodec.forPaper("shared-token");
+        PluginMessageCodec proxy = PluginMessageCodec.forProxy("shared-token");
         String requestId = UUID.randomUUID().toString();
         byte[] raw = ProtocolCodec.encodeSyncRequest(requestId);
-        byte[] wire = codec.encode(raw);
+        byte[] wire = paper.encode(raw);
 
-        ProtocolCodec.ParsedMessage parsed = codec.decode(wire);
+        ProtocolCodec.ParsedMessage parsed = proxy.decode(wire);
         assertNotNull(parsed);
         assertEquals(MessageType.SYNC_REQUEST, parsed.type());
         try (DataInputStream input = ProtocolCodec.payloadStream(parsed)) {
             assertEquals(requestId, input.readUTF());
         }
 
-        assertNull(new PluginMessageCodec("wrong-token").decode(wire));
-        assertNull(codec.decode(raw));
+        assertNull(PluginMessageCodec.forProxy("wrong-token").decode(wire));
+        assertNull(paper.decode(wire));
+        assertNull(proxy.decode(raw));
 
         wire[wire.length - 1] ^= 1;
-        assertNull(codec.decode(wire));
+        assertNull(proxy.decode(wire));
+
+        byte[] response = proxy.encode(ProtocolCodec.encodeSyncNoData(requestId));
+        assertNotNull(paper.decode(response));
+        assertNull(proxy.decode(response));
     }
 
     @Test
     public void rejectsMessagesAboveTheTransportLimit() {
-        PluginMessageCodec codec = new PluginMessageCodec("shared-token");
+        PluginMessageCodec codec = PluginMessageCodec.forPaper("shared-token");
         assertThrows(IllegalArgumentException.class,
                 () -> codec.encode(new byte[dev.twme.worldeditsync.common.Constants.MAX_PLUGIN_MESSAGE_SIZE]));
+    }
+
+    @Test
+    public void rejectsRandomMalformedEnvelopesWithoutThrowing() {
+        PluginMessageCodec codec = PluginMessageCodec.forPaper("shared-token");
+        Random random = new Random(0x574553L);
+
+        for (int attempt = 0; attempt < 1_000; attempt++) {
+            byte[] malformed = new byte[random.nextInt(4_096)];
+            random.nextBytes(malformed);
+            assertNull(codec.decode(malformed));
+        }
+
+        assertNull(codec.decode(new byte[dev.twme.worldeditsync.common.Constants.MAX_PLUGIN_MESSAGE_SIZE + 1]));
     }
 }

--- a/src/test/java/dev/twme/worldeditsync/common/protocol/TransferMemoryBudgetTest.java
+++ b/src/test/java/dev/twme/worldeditsync/common/protocol/TransferMemoryBudgetTest.java
@@ -1,0 +1,76 @@
+package dev.twme.worldeditsync.common.protocol;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.Test;
+
+public class TransferMemoryBudgetTest {
+
+    @Test
+    public void atomicallyBoundsAndReusesReservations() {
+        TransferMemoryBudget budget = new TransferMemoryBudget(10L);
+
+        assertTrue(budget.tryReserve(6L));
+        assertFalse(budget.tryReserve(5L));
+        assertEquals(6L, budget.getReservedBytes());
+        budget.release(6L);
+        assertTrue(budget.tryReserve(10L));
+        assertEquals(10L, budget.getReservedBytes());
+    }
+
+    @Test
+    public void rejectsInvalidAndUnbalancedReservations() {
+        TransferMemoryBudget budget = new TransferMemoryBudget(10L);
+
+        assertFalse(budget.tryReserve(0L));
+        assertFalse(budget.tryReserve(11L));
+        assertThrows(IllegalStateException.class, () -> budget.release(1L));
+        assertEquals(0L, budget.getReservedBytes());
+    }
+
+    @Test
+    public void concurrentReservationsNeverExceedTheLimit() throws Exception {
+        int contenders = 32;
+        TransferMemoryBudget budget = new TransferMemoryBudget(8L);
+        CyclicBarrier start = new CyclicBarrier(contenders);
+        ExecutorService executor = Executors.newFixedThreadPool(contenders);
+        try {
+            List<Callable<Boolean>> attempts = new ArrayList<>();
+            for (int index = 0; index < contenders; index++) {
+                attempts.add(() -> {
+                    start.await();
+                    return budget.tryReserve(1L);
+                });
+            }
+
+            List<Future<Boolean>> results = executor.invokeAll(attempts);
+            long accepted = results.stream().filter(result -> {
+                try {
+                    return result.get();
+                } catch (Exception exception) {
+                    throw new AssertionError(exception);
+                }
+            }).count();
+
+            assertEquals(8L, accepted);
+            assertEquals(8L, budget.getReservedBytes());
+            for (long index = 0; index < accepted; index++) {
+                budget.release(1L);
+            }
+            assertEquals(0L, budget.getReservedBytes());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/src/test/java/dev/twme/worldeditsync/common/protocol/TransferSessionTest.java
+++ b/src/test/java/dev/twme/worldeditsync/common/protocol/TransferSessionTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
 
@@ -11,7 +12,7 @@ public class TransferSessionTest {
 
     @Test
     public void assemblesOutOfOrderChunksExactlyOnce() {
-        TransferSession session = new TransferSession("session", 2, 5, "hash");
+        TransferSession session = new TransferSession("session", 2, 5, 3, "hash");
 
         assertTrue(session.addChunk(1, new byte[] {4, 5}));
         assertFalse(session.isComplete());
@@ -19,12 +20,14 @@ public class TransferSessionTest {
         assertTrue(session.isComplete());
         assertTrue(session.tryClaimCompletion());
         assertFalse(session.tryClaimCompletion());
-        assertArrayEquals(new byte[] {1, 2, 3, 4, 5}, session.assemble());
+        byte[] assembled = session.assemble();
+        assertArrayEquals(new byte[] {1, 2, 3, 4, 5}, assembled);
+        assertSame(assembled, session.assemble());
     }
 
     @Test
     public void ignoresDuplicateChunkWithoutReplacingData() {
-        TransferSession session = new TransferSession("session", 1, 2, "hash");
+        TransferSession session = new TransferSession("session", 1, 2, 2, "hash");
 
         assertTrue(session.addChunk(0, new byte[] {1, 2}));
         assertFalse(session.addChunk(0, new byte[] {9, 9}));
@@ -33,7 +36,7 @@ public class TransferSessionTest {
 
     @Test
     public void rejectsInvalidChunkIndexAndOverflow() {
-        TransferSession session = new TransferSession("session", 2, 3, "hash");
+        TransferSession session = new TransferSession("session", 2, 3, 2, "hash");
 
         assertThrows(IllegalArgumentException.class,
                 () -> session.addChunk(2, new byte[] {1}));
@@ -51,8 +54,21 @@ public class TransferSessionTest {
 
     @Test
     public void expiresAtTheConfiguredDeadline() {
-        TransferSession session = new TransferSession("session", 1, 1, "hash");
+        TransferSession session = new TransferSession("session", 1, 1, 1, "hash");
 
         assertTrue(session.isExpired(0));
+    }
+
+    @Test
+    public void releaseDropsDataAndPreventsReuse() {
+        TransferSession session = new TransferSession("session", 1, 2, 2, "hash");
+        session.addChunk(0, new byte[] {1, 2});
+
+        session.release();
+
+        assertFalse(session.isComplete());
+        assertThrows(IllegalStateException.class, session::assemble);
+        assertThrows(IllegalStateException.class,
+                () -> session.addChunk(0, new byte[] {1, 2}));
     }
 }

--- a/src/test/java/dev/twme/worldeditsync/common/storage/ProxyClipboardStoreTest.java
+++ b/src/test/java/dev/twme/worldeditsync/common/storage/ProxyClipboardStoreTest.java
@@ -1,0 +1,74 @@
+package dev.twme.worldeditsync.common.storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+
+import org.junit.Test;
+
+import dev.twme.worldeditsync.common.protocol.TransferSession;
+
+public class ProxyClipboardStoreTest {
+
+    @Test
+    public void evictsOldestClipboardInsteadOfExceedingMemoryBudget() {
+        ProxyClipboardStore store = new ProxyClipboardStore(5L);
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+
+        assertTrue(store.storeClipboard(first, new byte[] {1, 2, 3}, "first"));
+        assertTrue(store.storeClipboard(second, new byte[] {4, 5, 6}, "second"));
+
+        assertNull(store.getClipboard(first));
+        assertTrue(store.hasClipboard(second));
+        assertEquals(3L, store.getUsedMemoryBytes());
+    }
+
+    @Test
+    public void reservesDeclaredUploadBytesBeforeAllocatingChunks() {
+        ProxyClipboardStore store = new ProxyClipboardStore(4L);
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+        TransferSession full = new TransferSession("full", 1, 4, 4, "hash");
+        TransferSession extra = new TransferSession("extra", 1, 1, 1, "hash");
+
+        assertTrue(store.addUploadSession("full", first, full));
+        assertEquals(4L, store.getReservedUploadBytes());
+        assertFalse(store.addUploadSession("extra", second, extra));
+        assertEquals(4L, store.getUsedMemoryBytes());
+    }
+
+    @Test
+    public void completionMovesReservationWithoutDuplicatingAccounting() {
+        ProxyClipboardStore store = new ProxyClipboardStore(4L);
+        UUID playerId = UUID.randomUUID();
+        TransferSession session = new TransferSession("upload", 1, 4, 4, "hash");
+        assertTrue(store.addUploadSession("upload", playerId, session));
+        session.addChunk(0, new byte[] {1, 2, 3, 4});
+
+        assertTrue(store.completeUploadSession("upload", playerId, session));
+
+        assertEquals(0L, store.getReservedUploadBytes());
+        assertEquals(4L, store.getStoredBytes());
+        assertEquals(4L, store.getUsedMemoryBytes());
+    }
+
+    @Test
+    public void cleanupReleasesExpiredCompletedSessions() {
+        ProxyClipboardStore store = new ProxyClipboardStore(4L);
+        UUID playerId = UUID.randomUUID();
+        TransferSession session = new TransferSession("upload", 1, 4, 4, "hash");
+        assertTrue(store.addUploadSession("upload", playerId, session));
+        session.addChunk(0, new byte[] {1, 2, 3, 4});
+
+        store.cleanupExpiredSessions(0L);
+
+        assertFalse(store.hasActiveUpload(playerId));
+        assertEquals(0L, store.getUsedMemoryBytes());
+        assertThrows(IllegalStateException.class, session::assemble);
+    }
+}

--- a/src/test/java/dev/twme/worldeditsync/common/storage/SingleUploadSessionTest.java
+++ b/src/test/java/dev/twme/worldeditsync/common/storage/SingleUploadSessionTest.java
@@ -50,11 +50,10 @@ public class SingleUploadSessionTest {
 
         assertTrue(store.addUploadSession("first", playerId, first));
         assertTrue(store.addUploadSession("second", playerId, second));
-        assertFalse(store.completeUploadSession("first", playerId, first,
-                new byte[] {1}, "first-hash"));
+        assertFalse(store.completeUploadSession("first", playerId, first));
         assertNull(store.getClipboard(playerId));
-        assertTrue(store.completeUploadSession("second", playerId, second,
-                new byte[] {2}, "second-hash"));
+        second.addChunk(0, new byte[] {2});
+        assertTrue(store.completeUploadSession("second", playerId, second));
         assertArrayEquals(new byte[] {2}, store.getClipboard(playerId).getData());
         assertFalse(store.hasActiveUpload(playerId));
     }
@@ -73,8 +72,7 @@ public class SingleUploadSessionTest {
         assertTrue(store.addUploadSession("complete", playerId, complete));
         store.removeIncompleteUploadSessionForOwner(playerId);
         assertSame(complete, store.getUploadSession("complete"));
-        assertTrue(store.completeUploadSession(
-                "complete", playerId, complete, new byte[] {1}, "hash"));
+        assertTrue(store.completeUploadSession("complete", playerId, complete));
     }
 
     @Test
@@ -91,8 +89,7 @@ public class SingleUploadSessionTest {
         assertTrue(store.addUploadSession("complete", playerId, complete));
         store.removeIncompleteUploadSessionForOwner(playerId);
         assertSame(complete, store.getUploadSession("complete"));
-        assertTrue(store.completeUploadSession(
-                "complete", playerId, complete, new byte[] {1}, "hash"));
+        assertTrue(store.completeUploadSession("complete", playerId, complete));
     }
 
     @Test
@@ -136,16 +133,15 @@ public class SingleUploadSessionTest {
 
         assertTrue(store.addUploadSession("first", playerId, first));
         assertTrue(store.addUploadSession("second", playerId, second));
-        assertFalse(store.completeUploadSession("first", playerId, first,
-                new byte[] {1}, "first-hash"));
+        assertFalse(store.completeUploadSession("first", playerId, first));
         assertNull(store.getClipboard(playerId));
-        assertTrue(store.completeUploadSession("second", playerId, second,
-                new byte[] {2}, "second-hash"));
+        second.addChunk(0, new byte[] {2});
+        assertTrue(store.completeUploadSession("second", playerId, second));
         assertArrayEquals(new byte[] {2}, store.getClipboard(playerId).getData());
         assertFalse(store.hasActiveUpload(playerId));
     }
 
     private TransferSession session(String id) {
-        return new TransferSession(id, 1, 1, "hash");
+        return new TransferSession(id, 1, 1, 1, "hash");
     }
 }

--- a/src/test/java/dev/twme/worldeditsync/paper/clipboard/ClipboardManagerTest.java
+++ b/src/test/java/dev/twme/worldeditsync/paper/clipboard/ClipboardManagerTest.java
@@ -1,0 +1,85 @@
+package dev.twme.worldeditsync.paper.clipboard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Test;
+
+import dev.twme.worldeditsync.common.Constants;
+import dev.twme.worldeditsync.common.model.SyncState;
+import dev.twme.worldeditsync.common.protocol.TransferMemoryBudget;
+import dev.twme.worldeditsync.common.protocol.TransferSession;
+
+public class ClipboardManagerTest {
+
+    @Test
+    public void skipsOnlyTheSameRecentlyConfirmedClipboard() {
+        AtomicLong clock = new AtomicLong(10_000L);
+        ClipboardManager manager = new ClipboardManager(clock::get);
+        UUID playerId = UUID.randomUUID();
+        Object clipboard = new Object();
+        String hash = "a".repeat(64);
+        manager.initPlayer(playerId, SyncState.IDLE);
+        manager.setLocalHash(playerId, hash);
+        manager.markSerializedClipboard(playerId, clipboard, hash);
+
+        assertTrue(manager.isSerializedClipboard(playerId, clipboard));
+        assertFalse(manager.isSerializedClipboard(playerId, new Object()));
+
+        clock.addAndGet(Constants.UNCHANGED_CLIPBOARD_RECHECK_MS);
+        assertFalse(manager.isSerializedClipboard(playerId, clipboard));
+    }
+
+    @Test
+    public void changedOrUnconfirmedHashForcesSerialization() {
+        ClipboardManager manager = new ClipboardManager();
+        UUID playerId = UUID.randomUUID();
+        Object clipboard = new Object();
+        manager.initPlayer(playerId, SyncState.IDLE);
+        manager.markSerializedClipboard(playerId, clipboard, "a".repeat(64));
+
+        assertFalse(manager.isSerializedClipboard(playerId, clipboard));
+        manager.setLocalHash(playerId, "b".repeat(64));
+        assertFalse(manager.isSerializedClipboard(playerId, clipboard));
+    }
+
+    @Test
+    public void shutdownOwnsAndReleasesDetachedDownloadExactlyOnce() {
+        ClipboardManager manager = new ClipboardManager();
+        TransferMemoryBudget budget = new TransferMemoryBudget(4L);
+        TransferSession session = new TransferSession("download", 1, 4, 4, "hash");
+        manager.setTransferMemoryBudget(budget);
+
+        assertTrue(manager.addDownloadSession("download", session));
+        session.addChunk(0, new byte[] {1, 2, 3, 4});
+        assertTrue(manager.detachDownloadSession("download", session));
+        assertEquals(4L, budget.getReservedBytes());
+
+        manager.shutdown();
+        manager.releaseDetachedDownloadSession(session);
+
+        assertEquals(0L, budget.getReservedBytes());
+        assertThrows(IllegalStateException.class, session::assemble);
+    }
+
+    @Test
+    public void rejectedDuplicateSessionDoesNotConsumeTransferBudget() {
+        ClipboardManager manager = new ClipboardManager();
+        TransferMemoryBudget budget = new TransferMemoryBudget(8L);
+        manager.setTransferMemoryBudget(budget);
+
+        assertTrue(manager.addDownloadSession(
+                "same", new TransferSession("same", 1, 4, 4, "hash")));
+        assertFalse(manager.addDownloadSession(
+                "same", new TransferSession("same", 1, 4, 4, "hash")));
+
+        assertEquals(4L, budget.getReservedBytes());
+        manager.shutdown();
+        assertEquals(0L, budget.getReservedBytes());
+    }
+}

--- a/src/test/java/dev/twme/worldeditsync/paper/clipboard/ClipboardSerializerTest.java
+++ b/src/test/java/dev/twme/worldeditsync/paper/clipboard/ClipboardSerializerTest.java
@@ -2,7 +2,12 @@ package dev.twme.worldeditsync.paper.clipboard;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -11,17 +16,31 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import org.enginehub.linbus.stream.LinBinaryIO;
 import org.enginehub.linbus.tree.LinCompoundTag;
+import org.enginehub.linbus.tree.LinIntTag;
+import org.enginehub.linbus.tree.LinListTag;
 import org.enginehub.linbus.tree.LinRootEntry;
 import org.enginehub.linbus.tree.LinTagType;
 import org.junit.Test;
 
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.platform.Capability;
+import com.sk89q.worldedit.extension.platform.Platform;
+import com.sk89q.worldedit.extension.platform.Preference;
+import com.sk89q.worldedit.event.platform.PlatformsRegisteredEvent;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardWriter;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.world.registry.BundledRegistries;
 
 public class ClipboardSerializerTest {
 
@@ -72,17 +91,132 @@ public class ClipboardSerializerTest {
         assertFalse(metadata.value().containsKey("Date"));
     }
 
+    @Test
+    public void rejectsWriterOutputBeforeItCanGrowPastTheConfiguredLimit() {
+        ClipboardSerializer serializer = new ClipboardSerializer() {
+            @Override
+            protected ClipboardWriter createWriter(OutputStream output) {
+                return new ClipboardWriter() {
+                    @Override
+                    public void write(Clipboard clipboard) throws IOException {
+                        output.write(new byte[6]);
+                    }
+
+                    @Override
+                    public void close() {
+                    }
+                };
+            }
+        };
+
+        assertThrows(IOException.class, () -> serializer.serialize(null, 5, 1));
+    }
+
+    @Test
+    public void rejectsExpandedDimensionsBeforeWorldEditAllocatesClipboard() throws Exception {
+        ClipboardSerializer serializer = new ClipboardSerializer();
+        byte[] oversized = schematicWithDimensions(256, 256, 256, 1000L);
+
+        assertThrows(IOException.class,
+                () -> serializer.canonicalize(oversized, 1024 * 1024, 1000L));
+    }
+
+    @Test
+    public void streamingValidationPreservesNestedListsArraysAndScalars() throws Exception {
+        ClipboardSerializer serializer = new ClipboardSerializer();
+        LinCompoundTag schematic = LinCompoundTag.builder()
+                .putInt("Version", 3)
+                .putShort("Width", (short) 1)
+                .putShort("Height", (short) 1)
+                .putShort("Length", (short) 1)
+                .putByte("Byte", (byte) 7)
+                .putLong("Long", 8L)
+                .putFloat("Float", 1.5F)
+                .putDouble("Double", 2.5D)
+                .putString("String", "stable")
+                .putByteArray("Bytes", new byte[] {1, 2, 3})
+                .putIntArray("Ints", new int[] {4, 5, 6})
+                .putLongArray("Longs", new long[] {7L, 8L, 9L})
+                .put("List", LinListTag.of(
+                        LinTagType.intTag(), List.of(LinIntTag.of(10), LinIntTag.of(11))))
+                .put("Nested", LinCompoundTag.builder().putString("Name", "value").build())
+                .build();
+
+        LinCompoundTag result = readRoot(serializer.canonicalize(
+                writeRoot(schematic), 1024 * 1024, 1L))
+                .value()
+                .findTag("Schematic", LinTagType.compoundTag());
+
+        assertEquals(schematic, result);
+    }
+
+    @Test
+    public void validatesOutputFromTheRealWorldEditWriter() throws Exception {
+        WorldEdit worldEdit = WorldEdit.getInstance();
+        Platform platform = mock(Platform.class);
+        when(platform.getCapabilities()).thenReturn(
+                Map.of(Capability.WORLD_EDITING, Preference.PREFERRED));
+        when(platform.getRegistries()).thenReturn(BundledRegistries.getInstance());
+        when(platform.getDataVersion()).thenReturn(4_189);
+        when(platform.getPlatformName()).thenReturn("test");
+        when(platform.getPlatformVersion()).thenReturn("1");
+        when(platform.getVersion()).thenReturn("1");
+        when(platform.id()).thenReturn("test");
+        worldEdit.getPlatformManager().register(platform);
+        try {
+            worldEdit.getPlatformManager().handlePlatformsRegistered(
+                    new PlatformsRegisteredEvent());
+            ClipboardSerializer serializer = new ClipboardSerializer();
+            Clipboard original = mock(Clipboard.class);
+            CuboidRegion region = new CuboidRegion(
+                    BlockVector3.ZERO, BlockVector3.at(1, 1, 1));
+            BaseBlock block = mock(BaseBlock.class);
+            BlockState blockState = mock(BlockState.class);
+            when(original.getRegion()).thenReturn(region);
+            when(original.getOrigin()).thenReturn(BlockVector3.at(1, 0, 1));
+            when(original.getMinimumPoint()).thenReturn(BlockVector3.ZERO);
+            when(original.getEntities()).thenReturn(List.of());
+            when(original.hasBiomes()).thenReturn(false);
+            when(original.getFullBlock(any(BlockVector3.class))).thenReturn(block);
+            when(block.toImmutableState()).thenReturn(blockState);
+            when(blockState.getAsString()).thenReturn("minecraft:stone");
+
+            byte[] data = serializer.serialize(original, 1024 * 1024, 8L);
+            LinCompoundTag schematic = readRoot(data).value()
+                    .findTag("Schematic", LinTagType.compoundTag());
+            LinCompoundTag metadata = schematic.findTag(
+                    "Metadata", LinTagType.compoundTag());
+
+            assertNotNull(schematic.findTag("Blocks", LinTagType.compoundTag()));
+            assertNotNull(metadata);
+            assertFalse(metadata.value().containsKey("Date"));
+        } finally {
+            worldEdit.getPlatformManager().unregister(platform);
+        }
+    }
+
     private static byte[] schematicWithDate(long date) throws IOException {
+        return schematicWithDimensions(1, 1, 1, date);
+    }
+
+    private static byte[] schematicWithDimensions(
+            int width, int height, int length, long date) throws IOException {
         LinCompoundTag metadata = LinCompoundTag.builder()
                 .putLong("Date", date)
                 .putString("Stable", "value")
                 .build();
         LinCompoundTag schematic = LinCompoundTag.builder()
                 .putInt("Version", 3)
+                .putShort("Width", (short) width)
+                .putShort("Height", (short) height)
+                .putShort("Length", (short) length)
                 .put("Metadata", metadata)
                 .build();
-        LinRootEntry root = new LinRootEntry(
-                "",
+        return writeRoot(schematic);
+    }
+
+    private static byte[] writeRoot(LinCompoundTag schematic) throws IOException {
+        LinRootEntry root = new LinRootEntry("",
                 LinCompoundTag.builder().put("Schematic", schematic).build());
 
         ByteArrayOutputStream output = new ByteArrayOutputStream();

--- a/src/test/java/dev/twme/worldeditsync/paper/s3/S3StorageManagerTest.java
+++ b/src/test/java/dev/twme/worldeditsync/paper/s3/S3StorageManagerTest.java
@@ -1,0 +1,35 @@
+package dev.twme.worldeditsync.paper.s3;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.logging.Logger;
+
+import org.junit.Test;
+
+import dev.twme.worldeditsync.common.crypto.MessageCipher;
+import io.minio.MinioClient;
+
+public class S3StorageManagerTest {
+
+    @Test
+    public void closesClientWhenInitializationFails() throws Exception {
+        MinioClient client = mock(MinioClient.class);
+        when(client.bucketExists(any())).thenThrow(new IllegalStateException("unavailable"));
+        S3StorageManager storage = new S3StorageManager(
+                "http://127.0.0.1:9000", "access", "secret", "bucket", "",
+                new MessageCipher("token"), 1024, mock(Logger.class)) {
+            @Override
+            protected MinioClient createClient() {
+                return client;
+            }
+        };
+
+        assertNull(storage.initialize());
+
+        verify(client).close();
+    }
+}

--- a/src/test/java/dev/twme/worldeditsync/paper/storage/S3ClipboardStorageTest.java
+++ b/src/test/java/dev/twme/worldeditsync/paper/storage/S3ClipboardStorageTest.java
@@ -1,0 +1,27 @@
+package dev.twme.worldeditsync.paper.storage;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import dev.twme.worldeditsync.paper.s3.S3StorageManager;
+import io.minio.MinioClient;
+
+public class S3ClipboardStorageTest {
+
+    @Test
+    public void closeReleasesMinioHttpResources() throws Exception {
+        S3StorageManager manager = mock(S3StorageManager.class);
+        MinioClient client = mock(MinioClient.class);
+        when(manager.initialize()).thenReturn(client);
+        S3ClipboardStorage storage = new S3ClipboardStorage(manager);
+
+        assertTrue(storage.initialize());
+        storage.close();
+
+        verify(client).close();
+    }
+}

--- a/src/test/java/dev/twme/worldeditsync/velocity/handler/MessageHandlerTest.java
+++ b/src/test/java/dev/twme/worldeditsync/velocity/handler/MessageHandlerTest.java
@@ -48,7 +48,8 @@ public class MessageHandlerTest {
         when(player.getCurrentServer()).thenReturn(Optional.of(connection));
 
         ClipboardStore store = new ClipboardStore();
-        PluginMessageCodec wireCodec = new PluginMessageCodec("test-token");
+        PluginMessageCodec paperCodec = PluginMessageCodec.forPaper("test-token");
+        PluginMessageCodec proxyCodec = PluginMessageCodec.forProxy("test-token");
         MessageHandler handler = new MessageHandler(
                 new Object(),
                 proxy,
@@ -58,19 +59,19 @@ public class MessageHandlerTest {
                 1024,
                 0,
                 30_000,
-                wireCodec,
+                proxyCodec,
                 mock(Logger.class));
 
         String sessionId = UUID.randomUUID().toString();
         String hash = "a".repeat(64);
         handler.handleMessage(player,
-                wireCodec.encode(ProtocolCodec.encodeUploadBegin(sessionId, 5, 2, hash)));
+                paperCodec.encode(ProtocolCodec.encodeUploadBegin(sessionId, 5, 2, hash)));
 
         assertNotNull(store.getUploadSession(sessionId));
         ArgumentCaptor<byte[]> messages = ArgumentCaptor.forClass(byte[].class);
         verify(connection, atLeastOnce()).sendPluginMessage(eq(channel), messages.capture());
 
-        ParsedMessage ready = wireCodec.decode(messages.getValue());
+        ParsedMessage ready = paperCodec.decode(messages.getValue());
         assertNotNull(ready);
         assertEquals(MessageType.UPLOAD_READY, ready.type());
         try (DataInputStream input = ProtocolCodec.payloadStream(ready)) {
@@ -78,9 +79,9 @@ public class MessageHandlerTest {
         }
 
         handler.handleMessage(player,
-                wireCodec.encode(ProtocolCodec.encodeUploadChunk(sessionId, 1, new byte[] {4, 5})));
+                paperCodec.encode(ProtocolCodec.encodeUploadChunk(sessionId, 1, new byte[] {4, 5})));
         handler.handleMessage(player,
-                wireCodec.encode(ProtocolCodec.encodeUploadChunk(sessionId, 0, new byte[] {1, 2, 3})));
+                paperCodec.encode(ProtocolCodec.encodeUploadChunk(sessionId, 0, new byte[] {1, 2, 3})));
 
         ClipboardPayload stored = store.getClipboard(playerId);
         assertNotNull(stored);


### PR DESCRIPTION
## Summary

- Harden Paper, BungeeCord, and Velocity plugin-message handling with directional AES-GCM keys, protocol validation, replay resistance, rate limits, and invalid-message circuit breakers.
- Bound transfer, proxy clipboard, NBT expansion, schematic dimensions, worker concurrency, and cleanup lifecycles to prevent memory and resource exhaustion.
- Keep clipboard serialization off server threads, avoid repeated scans, close S3/Redis/HTTP resources, and preserve Folia scheduler behavior.
- Compile the Velocity implementation against API 3.4.0 on Java 21 and API 4.0.0 on Java 25. Paper API target is 1.21.11.
- Update the README around installation, setup choices, Actionbar behavior, platform support, and the tested FAWE limitations.

## Verification

- Maven tests: 72 run, 0 failures, 0 errors, 2 external integration tests skipped.
- `mvn -Dvelocity-api.version=3.4.0 clean verify` on Java 21.
- `mvn -Dvelocity-api.version=4.0.0 clean verify` on Java 25.
- SpotBugs Max/High check passed.
- Live Mineflayer copy, reconnect, download, and paste flows passed on Paper 1.21.11 with WorldEdit and FAWE, Spigot 1.21.11 with WorldEdit, Folia 1.21.11 with WorldEdit, BungeeCord, and a local MinIO S3 endpoint.
- FAWE 2.15.3 worked on Paper; the tested FAWE build itself did not load on Spigot 1.21.11 and is documented as unavailable there and on Folia.

Protocol version is now 3; all participating backend and proxy instances must be upgraded together.